### PR TITLE
Bug synclogger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ha-meural
 **Integration for Meural Canvas digital art frame in Home Assistant**  
 
+*Last master update: 27 May 2020*  
+*Previous master update: 26 May 2020*  
+
 The Netgear Meural Canvas is a digital art frame with both a local interface and a cloud API.  
 Home Assistant is an open source home automation package that puts local control and privacy first.  
 This integration leverages Meural's API and local interface to control the Meural Canvas as a media player in Home Assistant.  
@@ -15,16 +18,14 @@ The integration supports built-in media player service calls to pause, play, go 
 *meural.toggle_informationcard*  
 These services are fully documented in services.yaml.
 
-The current artwork displayed in the Media Control card is polled from the Meural API. The Canvas normally only syncs to the Meural API once every few hours, which means the currently displayed artwork is often out-of-sync with the Meural API. This integration forces a sync when a mismatch between the local current artwork and the remote current artwork is detected. Because of this the artwork displayed in Home Assistant will have about 10 seconds of lag compared to local changes on your device.
-
 # Meural API
 Meural has a REST API that their mobile app and web-interface run on. Unofficial information on this API can be found here:
 https://documenter.getpostman.com/view/1657302/RVnWjKUL?version=latest
 
 # Local Web Server
-While Meural positions the mobile app as the main method to control the Canvas, they do refer to a 'remote controller' in their support documentation:  
+Netgear refers to a 'remote controller' in their Meural support documentation:  
 https://kb.netgear.com/000060746/Can-I-control-the-Canvas-without-a-mobile-app-or-gesture-control-and-if-so-how  
-This 'remote controller' is a local web server available at: http://LOCALIP/remote/  
+This 'remote controller' is a local web server on the Canvas device available at: http://LOCALIP/remote/  
 It runs on a javascript available at: http://LOCALIP/static/remote.js
 
 The available calls in this javascript are:  
@@ -57,10 +58,13 @@ The available calls in this javascript are:
 */remote/postcard/*  
 
 # Google Assistant
-Meural currently only supports Alexa voice commands. However, if your Home Assistant supports Google Assistant - either configured manually or via Nabu Casa - you can expose the Canvas entity and control it via Google Assistant.
-Currently you can turn the Canvas on and off, and select different playlists for the Canvas to display. Change the name of your Canvas to something you can pronounce. If you want to call your Canvas 'Meural', spell it 'Mural'.  
+Meural currently only supports Alexa voice commands for the Canvas. However, if your Home Assistant supports Google Assistant - either configured manually or via Nabu Casa - you can expose the Canvas entity and control it via Google Assistant. A media player in Home Assistant exposes OnOff and Modes to Google. This means you can turn the Canvas on or off and select different playlists for the Canvas to display. Change the name of your Canvas to something you can pronounce - if you want to call your Canvas 'Meural', spell it 'Mural'. For example, say:  
 *"Hey Google, turn on (canvas name)."*  
+*"Hey Google, set input source to (playlist name) on (canvas name)."*  
 *"Hey Google, turn off (canvas name)."*  
-*"Hey Google, set input source to (playlist name) to (meural name)."*  
 
-First version of this integration built by [@balloob](https://github.com/balloob). All jury-rigged code added afterwards by [@guysie](https://github.com/guysie). I'm not a dev, so I apologize in advance for code quality.  
+A proof of concept video can be found here:
+https://twitter.com/GuySie/status/1265349696119283716
+
+# Thanks
+The first version of this integration was built by [@balloob](https://github.com/balloob) - many, many thanks to him. Blame [@guysie](https://github.com/guysie) for all code added afterwards. I'm not a dev, so I apologize in advance for code quality.  

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ha-meural
 **Integration for Meural Canvas digital art frame in Home Assistant**  
 
-*Last master update: 27 May 2020*  
+*Last master update: 28 May 2020*  
 *Previous master update: 26 May 2020*  
 
 The Netgear Meural Canvas is a digital art frame with both a local interface and a cloud API.  
@@ -58,7 +58,9 @@ The available calls in this javascript are:
 */remote/postcard/*  
 
 # Google Assistant
-Meural currently only supports Alexa voice commands for the Canvas. However, if your Home Assistant supports Google Assistant - either configured manually or via Nabu Casa - you can expose the Canvas entity and control it via Google Assistant. A media player in Home Assistant exposes OnOff and Modes to Google. This means you can turn the Canvas on or off and select different playlists for the Canvas to display. Change the name of your Canvas to something you can pronounce - if you want to call your Canvas 'Meural', spell it 'Mural'. For example, say:  
+Meural currently only supports Alexa voice commands for the Canvas. However, if your Home Assistant supports Google Assistant - either configured manually or via Nabu Casa - you can expose the Canvas entity and control it via Google Assistant. A media player in Home Assistant exposes OnOff and Modes to Google. This means you can turn the Canvas on or off and select different playlists for the Canvas to display. Change the name of your Canvas to something you can pronounce - if you want to call your Canvas 'Meural', spell it 'Mural'.  
+
+For example, say:  
 *"Hey Google, turn on (canvas name)."*  
 *"Hey Google, set input source to (playlist name) on (canvas name)."*  
 *"Hey Google, turn off (canvas name)."*  

--- a/README.md
+++ b/README.md
@@ -4,21 +4,21 @@
 The Netgear Meural Canvas is a digital art frame with both a local interface and a cloud API.  
 Home Assistant is an open source home automation package that puts local control and privacy first.  
 This integration leverages Meural's API and local interface to control the Meural Canvas as a media player in Home Assistant.  
+
 # Installation
-Copy this integration into your Home Assistant's custom_components folder and restart Home Assistant. Log in with your Netgear account when setting up the integration. The integration will detect all Canvas devices registered to your account. Each Canvas will become a Media Player entity and can be added to your Lovelace UI using any component that supports it, for example the default Media Control card.  
+Copy the 'meural' folder into your Home Assistant's 'custom_components' folder and restart Home Assistant. Log in with your Netgear account when setting up the integration. The integration will detect all Canvas devices registered to your account. Each Canvas will become a Media Player entity and can be added to your Lovelace UI using any component that supports it, for example the default Media Control card.  
 
 The integration supports built-in media player service calls to pause, play, go to next/previous track (artwork), select source (art playlist), set shuffle, turn on and turn off. Additional services built into this integration are:  
-*meural.load_gallery*  
 *meural.set_device_option*  
-*meural.set_device_orientation*  
 *meural.set_brightness*  
 *meural.reset_brightness*  
+*meural.toggle_informationcard*  
 These services are fully documented in services.yaml.
 
-The current image displayed in the Media Control card is polled from the Meural API. The Canvas normally only syncs to the Meural API once every few hours, so the current displayed art is often out-of-sync with the Meural API. The integration forces a sync when a mismatch between the local current artwork and the remote current artwork is detected. Because of this the image displayed in Home Assistant will only have about 10 seconds of lag compared to local changes on your device.
+The current artwork displayed in the Media Control card is polled from the Meural API. The Canvas normally only syncs to the Meural API once every few hours, which means the currently displayed artwork is often out-of-sync with the Meural API. This integration forces a sync when a mismatch between the local current artwork and the remote current artwork is detected. Because of this the artwork displayed in Home Assistant will have about 10 seconds of lag compared to local changes on your device.
 
 # Meural API
-Meural has an undocumented REST API that their mobile app and web-interface run on. This API has been reverse-engineered and crowdsourced documentation can be found here:  
+Meural has a REST API that their mobile app and web-interface run on. Unofficial information on this API can be found here:
 https://documenter.getpostman.com/view/1657302/RVnWjKUL?version=latest
 
 # Local Web Server
@@ -55,5 +55,12 @@ The available calls in this javascript are:
 */remote/control_command_post/connect_to_hidden_wifi/*  
 */remote/control_command_post/delete_wifi_connection/*  
 */remote/postcard/*  
+
+# Google Assistant
+Meural currently only supports Alexa voice commands. However, if your Home Assistant supports Google Assistant - either configured manually or via Nabu Casa - you can expose the Canvas entity and control it via Google Assistant.
+Currently you can turn the Canvas on and off, and select different playlists for the Canvas to display. Change the name of your Canvas to something you can pronounce. If you want to call your Canvas 'Meural', spell it 'Mural'.  
+*"Hey Google, turn on (canvas name)."*  
+*"Hey Google, turn off (canvas name)."*  
+*"Hey Google, set input source to (playlist name) to (meural name)."*  
 
 First version of this integration built by [@balloob](https://github.com/balloob). All jury-rigged code added afterwards by [@guysie](https://github.com/guysie). I'm not a dev, so I apologize in advance for code quality.  

--- a/meural/manifest.json
+++ b/meural/manifest.json
@@ -2,7 +2,7 @@
   "domain": "meural",
   "name": "Meural",
   "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/meural",
+  "documentation": "https://github.com/GuySie/ha-meural",
   "requirements": [],
   "ssdp": [],
   "zeroconf": [],

--- a/meural/media_player.py
+++ b/meural/media_player.py
@@ -1,7 +1,10 @@
 import logging
 import voluptuous as vol
 
-from homeassistant.components.media_player import MediaPlayerEntity
+try:
+    from homeassistant.components.media_player import MediaPlayerEntity
+except ImportError:
+    from homeassistant.components.media_player import MediaPlayerDevice as MediaPlayerEntity
 
 from homeassistant.const import (
     STATE_PLAYING,
@@ -10,6 +13,7 @@ from homeassistant.const import (
 )
 
 from homeassistant.components.media_player.const import (
+    MEDIA_TYPE_MUSIC,
     SUPPORT_SELECT_SOURCE,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -63,19 +67,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
     platform.async_register_entity_service(
-        "set_device_orientation",
-        {
-            vol.Required("orientation"): str
-        },
-        "async_set_device_orientation",
-    )
-
-    platform.async_register_entity_service(
-        "load_gallery",
-        {
-            vol.Required("gallery"): str
-        },
-        "async_load_gallery",
+        "toggle_informationcard",
+        {},
+        "async_toggle_informationcard",
     )
 
     platform.async_register_entity_service(
@@ -123,6 +117,8 @@ class MeuralEntity(MediaPlayerEntity):
 
         self._pause_duration = 0
         self._sleep = True
+        self._media_content_id = 0
+        self._current_item = []
 
     @property
     def meural_device_id(self):
@@ -145,18 +141,24 @@ class MeuralEntity(MediaPlayerEntity):
         user_galleries = await self.meural.get_user_galleries()
         [device_galleries.append(x) for x in user_galleries if x not in device_galleries]
         self._galleries = device_galleries  
+        """Set up first item to display"""
+        localdata = await self.local_meural.send_get_gallery_status()
+        self._current_item = await self.meural.get_item(int(localdata["current_item"]))
 
     async def async_update(self):
         self._sleep = await self.local_meural.send_get_sleep()
 
-        self._meural_device = await self.meural.get_device(self.meural_device_id)
- 
-        localdata = await self.local_meural.send_get_gallery_status()
-        localitem = int(localdata["current_item"])
-        remoteitem = int(self._meural_device["frameStatus"]["currentItem"])
-        if localitem != remoteitem:
-            _LOGGER.warning("Syncing with Meural API because local item ID %s is not remote item ID %s", localitem, remoteitem)
-            await self.meural.sync_device(self.meural_device_id)
+        if self._sleep == False:
+            self._meural_device = await self.meural.get_device(self.meural_device_id)
+
+            remoteitem = int(self._meural_device["frameStatus"]["currentItem"])
+            localdata = await self.local_meural.send_get_gallery_status()
+            self._media_content_id = int(localdata["current_item"])
+
+            if self._media_content_id != remoteitem:
+                _LOGGER.warning("Syncing with Meural API because local item ID %s is not remote item ID %s", self._media_content_id, remoteitem)
+                await self.meural.sync_device(self.meural_device_id)
+                self._current_item = await self.meural.get_item(self._media_content_id)
 
     @property
     def name(self):
@@ -197,9 +199,46 @@ class MeuralEntity(MediaPlayerEntity):
         return [g["name"] for g in self._galleries]
 
     @property
+    def media_content_id(self):
+        """Return the content ID of current playing media."""
+        return self._media_content_id
+
+    @property
+    def media_content_type(self):
+        """Return the content type of current playing media. Photo/art type does not exist, use Music as alternative."""
+        return MEDIA_TYPE_MUSIC
+
+    @property
+    def media_summary(self):
+        """Return the summary of current playing media."""
+        return self._current_item["description"]
+
+    @property
+    def media_title(self):
+        """Return the title of current playing media."""
+        return self._current_item["name"]
+
+    @property
+    def media_artist(self):
+        """Artist of current playing media, music track only. Replaced with artist's name and the artwork's year."""        
+        if self._current_item["artistName"] is not None:
+            if self._current_item["year"] is not None:
+                return self._current_item["artistName"] + ", " + self._current_item["year"]
+            else:
+                return self._current_item["artistName"]
+        elif self._current_item["author"] is not None:
+            if self._current_item["year"] is not None:
+                return self._current_item["author"] + ", " + self._current_item["year"]
+            else:
+                return self._current_item["author"]
+        elif self._current_item["year"] is not None:
+            return "Unknown, " + str(self._current_item["year"])
+        return ""
+
+    @property
     def media_image_url(self):
         """Image url of current playing media."""
-        return self._meural_device["currentImage"]
+        return self._current_item["image"]
  
     @property
     def media_image_remotely_accessible(self) -> bool:
@@ -270,6 +309,9 @@ class MeuralEntity(MediaPlayerEntity):
     async def async_reset_brightness(self):
         await self.local_meural.send_als_calibrate_off()
 
+    async def async_toggle_informationcard(self):
+        await self.local_meural.send_key_up()
+
     async def async_select_source(self, source):
         """Select input source."""
         source = next((g["id"] for g in self._galleries if g["name"] == source), None)
@@ -308,19 +350,3 @@ class MeuralEntity(MediaPlayerEntity):
     async def async_set_shuffle(self, shuffle):
         """Enable/disable shuffling."""
         await self.meural.update_device(self.meural_device_id, {"imageShuffle": shuffle})
-
-    async def async_set_device_orientation(self, orientation):
-        """Set horizontal or vertical device orientation."""
-        if orientation == 'vertical':
-            await self.local_meural.send_set_portrait()
-        elif orientation == 'horizontal':
-            await self.local_meural.send_set_landscape()
-
-    async def async_load_gallery(self, gallery):
-        """Change gallery being displayed."""
-        gallery = next((g["id"] for g in self._galleries if g["name"] == gallery), None)
-        if gallery is None:
-            _LOGGER.warning("Source %s not found", gallery)
-        await self.meural.device_load_gallery(self.meural_device_id, gallery)
-
-        

--- a/meural/pymeural.py
+++ b/meural/pymeural.py
@@ -81,6 +81,9 @@ class PyMeural:
     async def sync_device(self, device_id):
         return await self.request("post", f"devices/{device_id}/sync")
 
+    async def get_item(self, item_id):
+        return await self.request("get", f"items/{item_id}")
+
 class LocalMeural:
     def __init__(self, device, session: aiohttp.ClientSession):
         self.ip = device["localIp"]

--- a/meural/services.yaml
+++ b/meural/services.yaml
@@ -15,24 +15,12 @@ reset_brightness:
     entity_id:
       description: Entity ID of the Meural Canvas to update.
       example: "media_player.meural-123"
-set_device_orientation:
-  description: Manually override the orientation of images on your Canvas.
+toggle_informationcard:
+  description: Toggle display of the information card, a museum-style placard, on your Canvas. 
   fields:
     entity_id:
-      description: Entity ID of the Meural Canvas to update.
+      description: Entity ID of the Meural Canvas to toggle display on.
       example: "media_player.meural-123"
-    orientation:
-      description: Desired orientation of images on your Canvas. Can be horizontal, vertical.
-      example: "vertical"
-load_gallery:
-  description: Change playlist being displayed on your Canvas.
-  fields:
-    entity_id:
-      description: Entity ID of the Meural Canvas to update.
-      example: "media_player.meural-123"
-    gallery:
-      description: Name of gallery to display.
-      example: "Gallery"
 set_device_option:
   description: Set the configuration options of a Meural Canvas.
   fields:
@@ -43,7 +31,7 @@ set_device_option:
       description: Override the orientation of images on your Canvas. Can be horizontal, vertical.
       example: "horizontal" 
     orientationMatch:
-      description: Your Canvas only shows images that match its current orientation, i.e. if your Canvas is in vertical, only vertical images will display. 
+      description: Your Canvas will only show images that match its current orientation, i.e. if your Canvas is in vertical, only vertical images will display. 
       example: "true"
     alsEnabled:
       description: Your Canvas will automatically adjusts its brightness to match its surroundings using the Ambient Light Sensor.
@@ -73,7 +61,7 @@ set_device_option:
       description: Your Canvas will show help text when displaying a preview of images in the playlist.
       example: "true"
     gestureFlip:
-      description: Your Canvas will invert horizontal gestures. Applies on image rotation in a playlist and on-screen menu selections.
+      description: Your Canvas will invert left/right controls. Applies on image rotation in a playlist and on-screen menu selections.
       example: "false"
     backgroundColor:
       description: Color displayed behind images that don't fill the frame. Can be grey, white, black.


### PR DESCRIPTION
Make importing MediaPlayerEntity backwards compatible with MediaPlayerDevice.

Base current item displayed solely on one source of information (get_item) instead of multiple (get_device and get_item) which can get out of sync.

Remove sync_device API call from update loop entirely, so we don't hammer Meural API with an expensive call. Current item data is retrieved via get_item based on local current item id. Item displayed in the Meural web-interface will now become out of sync with device again - but this is an issue for Meural to solve, not within scope of this integration.

Add properties media_content_type, media_title, media_artist and media_summary to display current item Artwork and Artist name in Media Control card. Media type is Music because there is no Photo/Art type, and Music's Song Title / Artist Title corresponds better to Artwork / Artist Name than the other media types.

Add meural.toggle_informationcard to display information card on Canvas.

Remove meural.load_gallery because redundant with media_player.select_source.

Remove meural.set_device_orientation because redundant with meural.set_device_option orientation.