### PR TITLE
Update usage async_sign_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 .DS_Store
+__pycache__


### PR DESCRIPTION
- Use keyword arguments to call async_sign_path so it will work with both old and new function signatures of async_sign_path.

- Also in Python we use `#` for code comments. Triple quote strings in a comment context are only used as docstrings at the start of functions. Rewrote a few.

- Simplified the play media source code a bit by returning earlier if we know we're going to print an error. 

- Browse media will not show unsupported media