### PR TITLE
Preview image via cloud upload and cleanup after

### DIFF
--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -85,7 +85,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             vol.Optional("author"): str,
             vol.Optional("description"): str,
             vol.Optional("medium"): str,
-            vol.Optional("year"): int,
+            vol.Optional("year"): str,
         },
         "async_preview_image_cloud",
     )

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -77,6 +77,21 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
     platform.async_register_entity_service(
+        "preview_image_cloud",
+        {
+            vol.Required("content_url"): str,
+            vol.Required("content_type"): str,
+            vol.Optional("name"): str,
+            vol.Optional("author"): str,
+            vol.Optional("description"): str,
+            vol.Optional("medium"): str,
+            vol.Optional("year"): int,
+        },
+        "async_preview_image_cloud",
+    )
+
+
+    platform.async_register_entity_service(
         "reset_brightness",
         {},
         "async_reset_brightness",
@@ -494,6 +509,14 @@ class MeuralEntity(MediaPlayerEntity):
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play media from media_source."""
+        use_cloud = kwargs.get("use_cloud", False)
+        if use_cloud:
+            name = kwargs.get("name")
+            author = kwargs.get("author")
+            description = kwargs.get("description")
+            medium = kwargs.get("medium")
+            year = kwargs.get("year")
+
         if media_source.is_media_source_id(media_id):
             sourced_media = await media_source.async_resolve_media(self.hass, media_id)
             media_type = sourced_media.mime_type
@@ -516,9 +539,11 @@ class MeuralEntity(MediaPlayerEntity):
                 # Prepend external URL.
                 hass_url = get_url(self.hass, allow_internal=True)
                 media_id = f"{hass_url}{media_id}"
-
             _LOGGER.info("Meural device %s: Playing media. Media type is %s, previewing image from %s", self.name, media_type, media_id)
-            await self.local_meural.send_postcard(media_id, media_type)
+            if use_cloud:
+                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year)
+            else:
+                await self.local_meural.send_postcard(media_id, media_type)
 
         # Play gallery (playlist or album) by ID.
         elif media_type in ['playlist']:
@@ -526,9 +551,12 @@ class MeuralEntity(MediaPlayerEntity):
             await self.local_meural.send_change_gallery(media_id)
 
         # "Preview image from URL.
-        elif media_type in [ 'image/jpg', 'image/png', 'image/jpeg' ]:
+        if media_type in [ 'image/jpg', 'image/png', 'image/jpeg', 'image/gif' ]:
             _LOGGER.info("Meural device %s: Playing media. Media type is %s, previewing image from %s", self.name, media_type, media_id)
-            await self.local_meural.send_postcard(media_id, media_type)
+            if use_cloud:
+                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year)
+            else:
+                await self.local_meural.send_postcard(media_id, media_type)
 
         # Play item (artwork) by ID. Play locally if item is in currently displayed gallery. If not, play using Meural server."""
         elif media_type in ['item']:
@@ -556,7 +584,15 @@ class MeuralEntity(MediaPlayerEntity):
         """Preview image from URL."""
         if content_type in [ 'image/jpg', 'image/png', 'image/jpeg' ]:
             _LOGGER.info("Meural device %s: Previewing image. Media type is %s, previewing image from %s", self.name, content_type, content_url)
-            await self.local_meural.send_postcard(content_url, content_type)
+            await self.async_play_media(media_type=content_type, media_id=content_url)
+        else:
+            _LOGGER.error("Meural device %s: Previewing image. Does not support media type %s", self.name, content_type)
+
+    async def async_preview_image_cloud(self, content_url, content_type, name=None, author=None, description=None, medium=None, year=None):
+        """Preview image from URL."""
+        if content_type in [ 'image/jpg', 'image/png', 'image/jpeg', 'image/gif' ]:
+            _LOGGER.info("Meural device %s: Previewing image via meural cloud. Media type is %s, previewing image from %s", self.name, content_type, content_url)
+            await self.async_play_media(media_type=content_type, media_id=content_url, use_cloud=True, name=name, author=author, description=description, medium=medium, year=year)
         else:
             _LOGGER.error("Meural device %s: Previewing image. Does not support media type %s", self.name, content_type)
 

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -543,7 +543,7 @@ class MeuralEntity(MediaPlayerEntity):
                 media_id = f"{hass_url}{media_id}"
             _LOGGER.info("Meural device %s: Playing media. Media type is %s, previewing image from %s", self.name, media_type, media_id)
             if use_cloud:
-                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year)
+                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year, duration)
             else:
                 await self.local_meural.send_postcard(media_id, media_type)
 
@@ -556,7 +556,7 @@ class MeuralEntity(MediaPlayerEntity):
         if media_type in [ 'image/jpg', 'image/png', 'image/jpeg', 'image/gif' ]:
             _LOGGER.info("Meural device %s: Playing media. Media type is %s, previewing image from %s", self.name, media_type, media_id)
             if use_cloud:
-                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year)
+                await self.meural.send_postcard_cloud(self._meural_device, media_id, media_type, name, author, description, medium, year, duration)
             else:
                 await self.local_meural.send_postcard(media_id, media_type)
 

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -86,6 +86,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             vol.Optional("description"): str,
             vol.Optional("medium"): str,
             vol.Optional("year"): str,
+            vol.Optional("duration"): int,
         },
         "async_preview_image_cloud",
     )
@@ -516,6 +517,7 @@ class MeuralEntity(MediaPlayerEntity):
             description = kwargs.get("description")
             medium = kwargs.get("medium")
             year = kwargs.get("year")
+            duration = kwargs.get("duration")
 
         if media_source.is_media_source_id(media_id):
             sourced_media = await media_source.async_resolve_media(self.hass, media_id)
@@ -588,11 +590,11 @@ class MeuralEntity(MediaPlayerEntity):
         else:
             _LOGGER.error("Meural device %s: Previewing image. Does not support media type %s", self.name, content_type)
 
-    async def async_preview_image_cloud(self, content_url, content_type, name=None, author=None, description=None, medium=None, year=None):
+    async def async_preview_image_cloud(self, content_url, content_type, name=None, author=None, description=None, medium=None, year=None, duration=None):
         """Preview image from URL."""
         if content_type in [ 'image/jpg', 'image/png', 'image/jpeg', 'image/gif' ]:
             _LOGGER.info("Meural device %s: Previewing image via meural cloud. Media type is %s, previewing image from %s", self.name, content_type, content_url)
-            await self.async_play_media(media_type=content_type, media_id=content_url, use_cloud=True, name=name, author=author, description=description, medium=medium, year=year)
+            await self.async_play_media(media_type=content_type, media_id=content_url, use_cloud=True, name=name, author=author, description=description, medium=medium, year=year, duration=duration)
         else:
             _LOGGER.error("Meural device %s: Previewing image. Does not support media type %s", self.name, content_type)
 

--- a/custom_components/meural/pymeural.py
+++ b/custom_components/meural/pymeural.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import json
-from datetime import datetime
+from datetime import date
 
 from typing import Dict
 import aiohttp
@@ -140,14 +140,12 @@ class PyMeural:
     async def update_content(self, id, name=None, author=None, description=None, medium=None, year=None):
         _LOGGER.info(f"Meural: Updating postcard. Id is {id}")
 
-        now = datetime.now()
-        dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
-
         name = "Homeassistant Preview Image" if name == None else name
         author = "Homeassistant" if author == None else author
         description = "Preview Image from Home Assistant Meural component" if description == None else description
         medium = "Photo" if medium == None else medium
-        year = dt_string if year == None else str(year)
+        # the year has to be a date. other format doesn't work
+        year = date.today() if year == None else str(year)
 
         data = aiohttp.FormData()
         data.add_field("name", name)
@@ -177,17 +175,13 @@ class PyMeural:
 
         data = aiohttp.FormData()
 
-        field_name = 'image'
-        if not (content_type == 'image/jpg' or content_type == 'image/jpeg'):
-            field_name = 'video'
-        data.add_field(field_name, content, filename=name,
+        data.add_field('image', content, filename=name,
                        content_type=content_type)
 
         response = await self.request("post", f"items",
                                       data=data, data_key="data")
 
-        _LOGGER.info('Meural: Sending postcard. %s uploaded' % (
-            field_name))
+        _LOGGER.info('Meural: Sending postcard. Image uploaded')
         return response
 
     async def preview_item(self, device_id, item_id):

--- a/custom_components/meural/pymeural.py
+++ b/custom_components/meural/pymeural.py
@@ -190,7 +190,7 @@ class PyMeural:
     async def delete_item(self, item_id):
         return await self.request("delete", f"items/{item_id}")
 
-    async def send_postcard_cloud(self, device, url, content_type, name, author, description, medium, year):
+    async def send_postcard_cloud(self, device, url, content_type, name, author, description, medium, year, duration):
         _LOGGER.info('Meural device %s: Uploading content. URL is %s' % (
             device['alias'], url))
         response = await self.upload_content(url, content_type=content_type, name=name)
@@ -204,13 +204,13 @@ class PyMeural:
         _LOGGER.info('Meural device %s: Sending postcard. Sent for preview: %s' % (
             device['alias'], item_id))
 
-        await asyncio.sleep(120)
+        duration = 60 if duration == None else duration
+        await asyncio.sleep(duration)
 
         response = await self.delete_item(item_id=item_id)
         _LOGGER.info('Meural device %s: Sending postcard. Deleted the item: %s' % (
             device['alias'], item_id))
         return response
-
 
 class LocalMeural:
     def __init__(self, device, session: aiohttp.ClientSession):

--- a/custom_components/meural/services.yaml
+++ b/custom_components/meural/services.yaml
@@ -65,7 +65,7 @@ preview_image_cloud:
       description: Medium for the media item
       example: Photography
     year:
-      description: Year
+      description: Year. This needs to be a date or just the year. Other format doesn't work
       example: 2022/05/01
 
 set_device_option:

--- a/custom_components/meural/services.yaml
+++ b/custom_components/meural/services.yaml
@@ -16,7 +16,7 @@ reset_brightness:
       description: Entity ID of the Meural Canvas to update.
       example: "media_player.meural-123"
 toggle_informationcard:
-  description: Toggle display of the information card, a museum-style placard, on your Canvas. 
+  description: Toggle display of the information card, a museum-style placard, on your Canvas.
   fields:
     entity_id:
       description: Entity ID of the Meural Canvas to toggle display on.
@@ -39,6 +39,35 @@ preview_image:
     content_type:
       description: The type of image to preview. Can be image/jpg or image/png.
       example: "image/png"
+
+preview_image_cloud:
+  description: Preview an image from an URL on Meural Canvas (Uses Meural cloud storage to work around the sticky image issue when displaying an image using local API).
+  fields:
+    entity_id:
+      description: Entity ID of the Meural Canvas to update.
+      example: "media_player.meural-123"
+    content_url:
+      description: URL of the image to preview.
+      example: "https://home-assistant.io/images/cast/splash.png"
+    content_type:
+      description: The type of image to preview. Can be image/jpg or image/png.
+      example: "image/png"
+    name:
+      description: Name of the media item
+      example: "Game of Thrones"
+    author:
+      description: Author or Artist name
+      example: George Martin
+    description:
+      description: Description for the media item
+      example: Game of Thrones Poster image
+    medium:
+      description: Medium for the media item
+      example: Photography
+    year:
+      description: Year
+      example: 2022/05/01
+
 set_device_option:
   description: Set the configuration options of a Meural Canvas.
   fields:
@@ -47,9 +76,9 @@ set_device_option:
       example: "media_player.meural-123"
     orientation:
       description: Override the orientation of images on your Canvas. Can be horizontal, vertical.
-      example: "horizontal" 
+      example: "horizontal"
     orientationMatch:
-      description: Your Canvas will only show images that match its current orientation, i.e. if your Canvas is in vertical, only vertical images will display. 
+      description: Your Canvas will only show images that match its current orientation, i.e. if your Canvas is in vertical, only vertical images will display.
       example: "true"
     alsEnabled:
       description: Your Canvas will automatically adjusts its brightness to match its surroundings using the Ambient Light Sensor.
@@ -84,7 +113,7 @@ set_device_option:
     backgroundColor:
       description: Color displayed behind images that don't fill the frame. Can be grey, white, black.
       example: "black"
-    fillMode: 
+    fillMode:
       description: How images will fill the screen if they don't match the Canvas' aspect ratio. Can be contain, auto crop, as is, stretch.
       example: "auto crop"
     galleryRotation:

--- a/custom_components/meural/util.py
+++ b/custom_components/meural/util.py
@@ -1,0 +1,7 @@
+from re import sub
+
+def snake_case(s):
+  return '_'.join(
+    sub('([A-Z][a-z]+)', r' \1',
+    sub('([A-Z]+)', r' \1',
+    s.replace('-', ' '))).split()).lower()


### PR DESCRIPTION
I spent way too much time troubleshooting this issue where previewing an image works only once and every subsequent attempt to preview an image will display the first image. For some reason, the Meural device caches the image. I verified this by making API calls directly to the local webserver. I also found someone mentioned this issue [here](https://github.com/GuySie/ha-meural/pull/15).

This had been bugging me for a while since I wanted to display the image from the front door when someone rings the doorbell. So for a while, I had automation where I used `preview_image` to display the image from the front door, then restart the Meural, so subsequent attempts to preview the image would work. Obviously, this wasn't ideal, so I looked into the APIs and figured out a way to upload the image first to the cloud and then use the id to preview it, waiting for 2 minutes before deleting it from the cloud.

Bonus:  You can include a bunch of metadata to the uploaded image, so the image preview looks great. 

## Screenshot
![meural preview image](https://user-images.githubusercontent.com/1029311/166606229-1cf5d42c-c371-4a5d-8713-ccdd1830f6b0.jpg)

P.S. I know this is kind of a hack to work around the preview service, so I am totally ok with closing this MR without merging. I am just going to leave this here, so if anyone struggling with this issue knows what to do :)
