### PR TITLE
Fix deprecated HA code usage

### DIFF
--- a/custom_components/meural/__init__.py
+++ b/custom_components/meural/__init__.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 from . import pymeural
@@ -38,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         entry.data["password"],
         entry.data["token"],
         token_update_callback,
-        hass.helpers.aiohttp_client.async_get_clientsession()
+        async_get_clientsession(hass)
     )
 
     for component in PLATFORMS:

--- a/custom_components/meural/__init__.py
+++ b/custom_components/meural/__init__.py
@@ -42,10 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async_get_clientsession(hass)
     )
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
Fix deprecated hass helpers usage (**removal  in 2024.11**): https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers/

Fix waiting for config entry platforms: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/  https://developers.home-assistant.io/docs/config_entries_index#for-platforms