### PR TITLE
Remove orientationMatch gsensor detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the ha-meural Home Assistant integration will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-03-03
+
+### Changed
+- **Reduced local API calls**: Removed `send_get_system()` call from the local polling cycle, reducing local device API calls from 4 to 3 per 10-second poll when the device is awake. The gsensor orientation data is no longer fetched or used.
+
+### Removed
+- **orientationMatch detection**: Removed automatic detection of physical device rotation via gsensor. The integration no longer reloads the current gallery when the device rotates with orientationMatch enabled. `current_item` metadata may be stale after a rotation until the gallery naturally advances.
+
 ## [2.0.0] - 2026-02-28
 - Modernized component to current Home Assistant best practices using Claude Code
 - Fixed longstanding bugs using Claude Code

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -211,20 +211,10 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             galleries = await self.local_meural.send_get_galleries()
             gallery_status = await self.local_meural.send_get_gallery_status()
 
-            # Get gsensor orientation for orientationMatch detection.
-            # Failure here is non-critical; omit the key so callers can detect absence.
-            gsensor = None
-            try:
-                system_info = await self.local_meural.send_get_system()
-                gsensor = system_info.get("gsensor")
-            except (aiohttp.ClientError, asyncio.TimeoutError):
-                pass
-
             return {
                 "sleeping": False,
                 "galleries": sorted(galleries, key=lambda i: i["name"]),
                 "gallery_status": gallery_status,
-                "gsensor": gsensor,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -200,7 +200,6 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         self._current_item: dict[str, Any] = {}
         self._pause_duration = 0
         self._last_fetched_item_id: int | None = None
-        self._last_gsensor: str | None = None
 
         # Start listening to local coordinator updates
         self.async_on_remove(
@@ -308,33 +307,11 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         self.cloud_coordinator.notify_sleep_state_changed()
 
         if self.local_coordinator.data:
-            # Detect physical rotation via gsensor when orientationMatch is enabled.
-            # gallery_status.current_item does not update on orientationMatch switches,
-            # so we use gsensor changes as the trigger to clear stale item metadata.
-            gsensor = self.local_coordinator.data.get("gsensor")
-            if (
-                gsensor is not None
-                and self._last_gsensor is not None
-                and gsensor != self._last_gsensor
-                and self._meural_device.get("orientationMatch")
-            ):
-                _LOGGER.debug(
-                    "Meural device %s: gsensor changed from %s to %s with orientationMatch enabled, reloading gallery to force item update",
-                    self.name,
-                    self._last_gsensor,
-                    gsensor,
-                )
-                self._current_item = {}
-                self._last_fetched_item_id = None
-                self.hass.async_create_task(self._reload_gallery_on_orientation_change())
-            else:
-                # When local data updates, fetch current item if it changed
-                gallery_status = self.local_coordinator.data.get("gallery_status", {})
-                if gallery_status:
-                    # Schedule fetching current item in the background
-                    self.hass.async_create_task(self._fetch_current_item_if_needed())
-            if gsensor is not None:
-                self._last_gsensor = gsensor
+            # When local data updates, fetch current item if it changed
+            gallery_status = self.local_coordinator.data.get("gallery_status", {})
+            if gallery_status:
+                # Schedule fetching current item in the background
+                self.hass.async_create_task(self._fetch_current_item_if_needed())
 
         self.async_write_ha_state()
 
@@ -625,40 +602,6 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         # Force immediate refresh for user-initiated actions (bypasses throttling)
         # This will automatically trigger _fetch_current_item_if_needed() via the coordinator update listener
         await self.local_coordinator.async_refresh()
-
-    async def _reload_gallery_on_orientation_change(self) -> None:
-        """Reload the current gallery after an orientationMatch rotation to force item update.
-
-        When the device physically rotates with orientationMatch enabled, it switches to an
-        orientation-appropriate item internally but gallery_status.current_item never updates
-        via the local API until the gallery naturally advances. Reloading the same gallery
-        forces the device to report the correct current_item.
-        """
-        if not self.local_coordinator.data:
-            return
-        gallery_status = self.local_coordinator.data.get("gallery_status", {})
-        current_gallery_id = gallery_status.get("current_gallery")
-        if not current_gallery_id or int(current_gallery_id) <= SD_CARD_FOLDER_MAX_ID:
-            return
-        _LOGGER.debug(
-            "Meural device %s: Reloading gallery %s to force current_item update after orientation change",
-            self.name,
-            current_gallery_id,
-        )
-        try:
-            # Wait for the orientation transition to complete before reloading.
-            # The transition animation takes several seconds; tune this if the reload
-            # still interrupts the transition or takes too long to respond.
-            await asyncio.sleep(5.0)
-            await self.local_meural.send_change_gallery(current_gallery_id)
-            await asyncio.sleep(1.0)
-            await self.local_coordinator.async_refresh()
-        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            _LOGGER.warning(
-                "Meural device %s: Error reloading gallery after orientation change: %s",
-                self.name,
-                err,
-            )
 
     async def async_select_source(self, source: str) -> None:
         """Select playlist to display."""


### PR DESCRIPTION
Removes the send_get_system() call from the local polling cycle. Also removes all gsensor tracking, the orientationMatch detection logic, and the _reload_gallery_on_orientation_change() method.