### PR TITLE
Update from Development branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **orientationMatch detection restored**: Automatic detection of physical device rotation via gsensor is back. The integration reloads the current gallery when the device rotates with orientationMatch enabled, keeping `current_item` metadata accurate.
-- **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API.
+- **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API. The local coordinator now polls `send_get_system()` even when the Canvas is sleeping, so the ambient light (lux) sensor — and other local sensors — continue to update every 10 seconds while the device is off. 
 - **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes.
 - **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm.
 - **Last Seen by Cloud sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the ha-meural Home Assistant integration will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - Unreleased
+
 ## [2.1.0] - 2026-03-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API.
 - **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes.
 - **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm.
-- **Last Cloud Contact sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
+- **Last Seen by Cloud sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
 - **Backlight light entity**: New light entity for the Canvas backlight, allowing brightness control and on/off. Turning the light off suspends the Canvas; turning it on wakes it.
 - **Local firmware version**: The Canvas firmware version shown in Home Assistant is now sourced from the local device API for accuracy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@ All notable changes to the ha-meural Home Assistant integration will be document
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0] - Unreleased
+## [2.2.0] - 2026-03-23
 
 ### Added
 - **orientationMatch detection restored**: Automatic detection of physical device rotation via gsensor is back. The integration reloads the current gallery when the device rotates with orientationMatch enabled, keeping `current_item` metadata accurate.
 - **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API. The local coordinator now polls `send_get_system()` even when the Canvas is sleeping, so the ambient light (lux) sensor — and other local sensors — continue to update every 10 seconds while the device is off. 
-- **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes.
-- **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm.
-- **Last Seen by Cloud sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
+- **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes. Disabled by default; enable in Home Assistant's entity settings.
+- **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm. Disabled by default; enable in Home Assistant's entity settings.
+- **Last Seen by Cloud sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring. Disabled by default; enable in Home Assistant's entity settings.
 - **Backlight light entity**: New light entity for the Canvas backlight, allowing brightness control and on/off. Turning the light off suspends the Canvas; turning it on wakes it.
 - **Local firmware version**: The Canvas firmware version shown in Home Assistant is now sourced from the local device API for accuracy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **orientationMatch detection restored**: Automatic detection of physical device rotation via gsensor is back. The integration reloads the current gallery when the device rotates with orientationMatch enabled, keeping `current_item` metadata accurate.
 - **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API.
-- **Free Space sensor**: New sensor reporting available Canvas storage space in megabytes.
-- **WiFi Signal sensor**: New sensor reporting Canvas WiFi signal strength in dBm.
-- **Last Cloud Contact sensor**: New sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
+- **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes.
+- **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm.
+- **Last Cloud Contact sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
 - **Backlight light entity**: New light entity for the Canvas backlight, allowing brightness control and on/off. Turning the light off suspends the Canvas; turning it on wakes it.
 - **Local firmware version**: The Canvas firmware version shown in Home Assistant is now sourced from the local device API for accuracy.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.2.0] - Unreleased
 
+### Added
+- **orientationMatch detection restored**: Automatic detection of physical device rotation via gsensor is back. The integration reloads the current gallery when the device rotates with orientationMatch enabled, keeping `current_item` metadata accurate.
+- **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API.
+- **Free Space sensor**: New sensor reporting available Canvas storage space in megabytes.
+- **WiFi Signal sensor**: New sensor reporting Canvas WiFi signal strength in dBm.
+- **Last Cloud Contact sensor**: New sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring.
+- **Backlight light entity**: New light entity for the Canvas backlight, allowing brightness control and on/off. Turning the light off suspends the Canvas; turning it on wakes it.
+- **Local firmware version**: The Canvas firmware version shown in Home Assistant is now sourced from the local device API for accuracy.
+
 ## [2.1.0] - 2026-03-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 **LocalDataUpdateCoordinator** (`coordinator.py:124-225`):
 - Polls local device API every 10 seconds
 - Each device has its own local coordinator instance
-- Fetches real-time state: sleep status, local galleries, gallery status, gsensor orientation
+- Fetches real-time state: sleep status, local galleries, gallery status, gsensor orientation, lux, free space, WiFi signal
 - Gracefully handles offline devices without failing the integration
 - Preserves last known sleep state on transient connection failures (no flickering)
 - Returns cached data when device is unreachable
@@ -60,6 +60,19 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Controls device directly without cloud dependency
 - Handles device sleep/wake detection
 
+**MeuralBacklightEntity** (`light.py`):
+- Light entity controlling the Canvas backlight brightness
+- Turning off suspends the Canvas device (equivalent to media player turn off)
+- Turning on wakes the Canvas device (equivalent to media player turn on)
+- Uses optimistic state updates for on/off; brightness changes apply immediately
+- Stays in sync with the media player entity — both reflect the same sleep/wake state
+
+**MeuralSensorEntities** (`sensor.py`):
+- **Ambient Light** (`MeuralLuxSensor`): illuminance in lux from local API; useful for automations
+- **Free Space** (`MeuralFreeSpaceSensor`): available Canvas storage in MB from local API; diagnostic
+- **WiFi Signal** (`MeuralWifiSignalSensor`): WiFi signal strength in dBm from local API; diagnostic
+- **Last Cloud Contact** (`MeuralLastSeenSensor`): timestamp of last cloud contact from cloud API; diagnostic
+
 **MeuralEntity** (`media_player.py`):
 - Media player entity implementing standard Home Assistant media player features
 - Coordinates between cloud and local data sources
@@ -70,6 +83,7 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Uses optimistic state updates for turn on/off, pause/play, and shuffle so the UI reflects changes instantly
 - Turn on: optimistically sets sleeping=False; device takes several seconds to wake so no immediate refresh (10s poll confirms)
 - Turn off: optimistically sets sleeping=True then confirms with an immediate refresh (device suspends quickly)
+- `sw_version` in `device_info` prefers local firmware version from `send_get_system()`, falls back to cloud value
 - `_cloud_only_galleries()`: computes galleries present in cloud (`device_galleries` + `user_galleries`) but not yet on the local device; used by `source_list`, `async_select_source`, `async_browse_media`, and `async_play_media`
 - Gallery selection tries local device first (via `send_change_gallery`); if not on device, falls back to cloud API (`device_load_gallery`)
 
@@ -97,6 +111,8 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - `__init__.py`: Integration setup, coordinator initialization
 - `coordinator.py`: Cloud and local data update coordinators
 - `media_player.py`: Media player entity implementation and custom services
+- `light.py`: Backlight light entity
+- `sensor.py`: Sensor entities (ambient light, free space, WiFi signal, last cloud contact)
 - `pymeural.py`: API clients for both cloud and local interfaces
 - `config_flow.py`: Configuration flow for UI setup
 - `const.py`: Constants (update intervals, domain name)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,10 +39,11 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Shared across all devices for a single account
 - Aggregates sleep state across all entities to determine polling interval
 
-**LocalDataUpdateCoordinator** (`coordinator.py:124-225`):
+**LocalDataUpdateCoordinator** (`coordinator.py:163-309`):
 - Polls local device API every 10 seconds
 - Each device has its own local coordinator instance
 - Fetches real-time state: sleep status, local galleries, gallery status, gsensor orientation, lux, free space, WiFi signal
+- When device is sleeping, skips gallery fetches but still polls `send_get_system()` so sensor data (lux, free space, WiFi signal) continues to update every 10 seconds
 - Gracefully handles offline devices without failing the integration
 - Preserves last known sleep state on transient connection failures (no flickering)
 - Returns cached data when device is unreachable
@@ -60,7 +61,7 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Controls device directly without cloud dependency
 - Handles device sleep/wake detection
 
-**MeuralBacklightEntity** (`light.py`):
+**MeuralBacklightLight** (`light.py`):
 - Light entity controlling the Canvas backlight brightness
 - Turning off suspends the Canvas device (equivalent to media player turn off)
 - Turning on wakes the Canvas device (equivalent to media player turn on)
@@ -68,10 +69,10 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Stays in sync with the media player entity — both reflect the same sleep/wake state
 
 **MeuralSensorEntities** (`sensor.py`):
-- **Ambient Light** (`MeuralLuxSensor`): illuminance in lux from local API; useful for automations
-- **Free Space** (`MeuralFreeSpaceSensor`): available Canvas storage in MB from local API; diagnostic
-- **WiFi Signal** (`MeuralWifiSignalSensor`): WiFi signal strength in dBm from local API; diagnostic
-- **Last Cloud Contact** (`MeuralLastSeenSensor`): timestamp of last cloud contact from cloud API; diagnostic
+- **Ambient Light** (`MeuralLuxSensor`): illuminance in lux from local API; enabled by default; useful for automations
+- **Free Space** (`MeuralFreeSpaceSensor`): available Canvas storage in MB from local API; diagnostic; disabled by default
+- **WiFi Signal** (`MeuralWifiSignalSensor`): WiFi signal strength in dBm from local API; diagnostic; disabled by default
+- **Last Seen by Cloud** (`MeuralLastSeenSensor`): timestamp of last cloud contact from cloud API; diagnostic; disabled by default
 
 **MeuralEntity** (`media_player.py`):
 - Media player entity implementing standard Home Assistant media player features

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ After restarting go to *Settings*, *Devices & Services*, *Integrations*, and cli
 
 Log in with your NETGEAR account.  
 
-The integration will detect all Canvas devices registered to your account. Each Canvas will become a Media Player entity and can be added to your dashboard using any component that supports it, for example the standard Media Control card. By default your entity's name will correspond to the name of the Canvas, which out-of-the-box consists of a painter's name and 3 digits like `picasso-428` - resulting in the entity `media_player.picasso-428` being created. You can override the name and entity ID in Home Assistant's entity settings.  
-
 **Note 1:** This integration does not yet support NETGEAR's two-step verification method of logging in. Please use the standard login and password method to use this integration.  
 
 **Note 2:** If you are upgrading to v2.0.0 from v1.x, the upgrade is fully backward compatible — no re-configuration or re-authentication is needed. Home Assistant will handle the migration automatically on restart. However, if you are upgrading from v0.x, you have to delete this integration in *Settings*, *Devices & Services*, *Integrations*, and then re-add it to log in again. This will set up the configuration entries required by v1.0.0 and later.  
 
-## Integration
-The integration supports built-in media player service calls to pause, play, play a specific item or playlist/album, go to the next/previous track (artwork), select a source (playlist/album), set shuffle mode, and turn on or turn off.
+### Media Player
+The integration will detect all Canvas devices registered to your account. Each Canvas will become a Media Player entity and can be added to your dashboard using any component that supports it, for example the standard Media Control card. By default your entity's name will correspond to the name of the Canvas, which out-of-the-box consists of a painter's name and 3 digits like `picasso-428` - resulting in the entity `media_player.picasso-428` being created. You can override the name and entity ID in Home Assistant's entity settings.  
+
+It supports built-in media player service calls to pause, play, play a specific item or playlist/album, go to the next/previous track (artwork), select a source (playlist/album), set shuffle mode, and turn on or turn off.
 - `media_player.media_pause`
 - `media_player.media_play`
 - `media_player.play_media`
@@ -54,6 +54,25 @@ Set parameter `media_content_type` to `item` and set parameter `media_content_id
 Set parameter `media_content_type` to `playlist` and parameter `media_content_id` to the gallery ID of the playlist or album that you wish to display. If the playlist is already loaded on the Canvas it will be selected directly; if it is only available in the cloud (i.e. not yet pushed to the Canvas), the integration will load it onto the Canvas via the cloud API first. When typing in gallery IDs manually, please note that albums are represented by a gallery ID on your Canvas that is not the same as their album ID on the Meural servers. To find out the gallery ID on your canvas, browse to `http://YOUR-CANVAS-IP/remote/get_galleries_json/` and locate the `id` tag next to the album or playlist name to use in the service call.
 
 ![Meural Canvas in entity settings](https://raw.githubusercontent.com/GuySie/ha-meural/master/images/entitysettings.png)
+
+### Backlight Light
+A **Light** entity is created for each Canvas to control the backlight brightness. This gives you a familiar light-style interface with a brightness slider, and also allows turning the Canvas on and off from the Lights dashboard or light automations.
+
+- **Turn on**: Wakes the Canvas device and optionally sets a specific brightness level.
+- **Turn off**: Suspends the Canvas device (same as `media_player.turn_off`).
+- **Brightness**: Sets the backlight level from 0–100%. Note that setting brightness via the `meural.set_brightness` service or the media player card simultaneously keeps both entities in sync.
+
+The backlight entity stays in sync with the media player entity — both reflect the same sleep/wake state.
+
+### Sensors
+Four sensor entities are created for each Canvas:
+
+- **Ambient Light** — Illuminance in lux from the local device API. Useful for automations that respond to room lighting conditions. Updates every 10 seconds, including while the Canvas is sleeping.
+- **Free Space** — Available Canvas storage in megabytes from the local device API. Diagnostic; disabled by default.
+- **WiFi Signal** — WiFi signal strength in dBm from the local device API. Diagnostic; disabled by default.
+- **Last Seen by Cloud** — Timestamp of the last time the device contacted the Meural cloud, from the cloud API. Useful for connectivity monitoring. Diagnostic; disabled by default.
+
+To enable a disabled diagnostic sensor, go to *Settings* → *Devices & Services* → *Meural* → select the Canvas device → click on the sensor entity → toggle "Enable entity".
 
 ### Other Services
 Additional services built into this integration are:

--- a/custom_components/meural/__init__.py
+++ b/custom_components/meural/__init__.py
@@ -10,11 +10,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
 from . import pymeural
-from .coordinator import CloudDataUpdateCoordinator
+from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["media_player"]
+PLATFORMS = ["media_player", "sensor"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
@@ -56,10 +56,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Populate gallery data synchronously so it is available immediately
     await cloud_coordinator.async_refresh_galleries()
 
-    # Store meural instance and coordinator in hass.data
+    # Create and initialize a LocalDataUpdateCoordinator for each device
+    devices = list(cloud_coordinator.data["devices"].values())
+    local_coordinators = {}
+    for device in devices:
+        local_coordinator = LocalDataUpdateCoordinator(
+            hass,
+            device,
+            async_get_clientsession(hass),
+        )
+        await local_coordinator.async_config_entry_first_refresh()
+        local_coordinators[str(device["id"])] = local_coordinator
+
+    # Store meural instance, coordinators, and devices in hass.data
     hass.data[DOMAIN][entry.entry_id] = {
         "meural": meural,
         "cloud_coordinator": cloud_coordinator,
+        "local_coordinators": local_coordinators,
     }
 
     # Forward to platform setup

--- a/custom_components/meural/__init__.py
+++ b/custom_components/meural/__init__.py
@@ -68,6 +68,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await local_coordinator.async_config_entry_first_refresh()
         local_coordinators[str(device["id"])] = local_coordinator
 
+    # Register local coordinators with the cloud coordinator so it can
+    # dynamically adjust its polling interval based on device sleep states.
+    for device_id, local_coordinator in local_coordinators.items():
+        cloud_coordinator.register_local_coordinator(device_id, local_coordinator)
+        local_coordinator.cloud_coordinator = cloud_coordinator
+    cloud_coordinator.notify_sleep_state_changed()
+
     # Store meural instance, coordinators, and devices in hass.data
     hass.data[DOMAIN][entry.entry_id] = {
         "meural": meural,
@@ -92,6 +99,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        cloud_coordinator = entry_data["cloud_coordinator"]
+        for device_id in entry_data["local_coordinators"]:
+            cloud_coordinator.unregister_local_coordinator(device_id)
 
     return unload_ok

--- a/custom_components/meural/__init__.py
+++ b/custom_components/meural/__init__.py
@@ -14,7 +14,7 @@ from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["media_player", "sensor"]
+PLATFORMS = ["media_player", "sensor", "light"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/custom_components/meural/config_flow.py
+++ b/custom_components/meural/config_flow.py
@@ -37,10 +37,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            _LOGGER.debug("Attempting authentication for %s", user_input["email"])
             try:
                 token, refresh_token = await validate_input(self.hass, user_input)
 
                 await self.async_set_unique_id(user_input["email"], raise_on_progress=False)
+                _LOGGER.info("Successfully authenticated Meural account %s", user_input["email"])
                 return self.async_create_entry(
                     title=user_input["email"],
                     data={
@@ -51,8 +53,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
             except pymeural.CannotConnect:
+                _LOGGER.warning("Cannot connect to Meural API for %s", user_input["email"])
                 errors["base"] = "cannot_connect"
             except pymeural.InvalidAuth:
+                _LOGGER.warning("Invalid credentials for Meural account %s", user_input["email"])
                 errors["base"] = "invalid_auth"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -211,10 +211,20 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             galleries = await self.local_meural.send_get_galleries()
             gallery_status = await self.local_meural.send_get_gallery_status()
 
+            # Get gsensor orientation for orientationMatch detection.
+            # Failure here is non-critical; omit the key so callers can detect absence.
+            gsensor = None
+            try:
+                system_info = await self.local_meural.send_get_system()
+                gsensor = system_info.get("gsensor")
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                pass
+
             return {
                 "sleeping": False,
                 "galleries": sorted(galleries, key=lambda i: i["name"]),
                 "gallery_status": gallery_status,
+                "gsensor": gsensor,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -215,10 +215,12 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Failure here is non-critical; omit the keys so callers can detect absence.
             gsensor = None
             lux = None
+            backlight = None
             try:
                 system_info = await self.local_meural.send_get_system()
                 gsensor = system_info.get("gsensor")
                 lux = system_info.get("lux")
+                backlight = system_info.get("backlight")
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 pass
 
@@ -228,6 +230,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "gallery_status": gallery_status,
                 "gsensor": gsensor,
                 "lux": lux,
+                "backlight": backlight,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -210,17 +210,36 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.cloud_coordinator.notify_sleep_state_changed()
 
             if self._sleeping:
-                # Device is sleeping; preserve last known sensor values to avoid unknown state
+                # Device is sleeping; skip gallery fetches but still poll sensor data —
+                # the local web server remains running during sleep mode.
                 cached = self.data or {}
+                gsensor = cached.get("gsensor")
+                lux = cached.get("lux")
+                backlight = cached.get("backlight")
+                free_space = cached.get("free_space")
+                wifi_signal = cached.get("wifi_signal")
+                version = cached.get("version")
+                try:
+                    system_info = await self.local_meural.send_get_system()
+                    gsensor = system_info.get("gsensor")
+                    lux = system_info.get("lux")
+                    backlight = system_info.get("backlight")
+                    free_space = system_info.get("free_space")
+                    wifi_status = system_info.get("wifi_status", {})
+                    wifi_signal = wifi_status.get("signal")
+                    version = system_info.get("version")
+                except (aiohttp.ClientError, asyncio.TimeoutError):
+                    pass  # Fall back to cached values initialized above
                 return {
                     "sleeping": True,
                     "galleries": cached.get("galleries", []),
                     "gallery_status": cached.get("gallery_status", {}),
-                    "gsensor": cached.get("gsensor"),
-                    "backlight": cached.get("backlight"),
-                    "free_space": cached.get("free_space"),
-                    "wifi_signal": cached.get("wifi_signal"),
-                    "version": cached.get("version"),
+                    "gsensor": gsensor,
+                    "lux": lux,
+                    "backlight": backlight,
+                    "free_space": free_space,
+                    "wifi_signal": wifi_signal,
+                    "version": version,
                 }
 
             # Device is awake, get full data

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -193,6 +193,13 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Return if device is sleeping."""
         return self._sleeping
 
+    def set_sleeping_optimistic(self, sleeping: bool) -> None:
+        """Set sleep state optimistically and notify all subscribed entities."""
+        self._sleeping = sleeping
+        if self.cloud_coordinator is not None:
+            self.cloud_coordinator.notify_sleep_state_changed()
+        self.async_update_listeners()
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch data from Meural local device API."""
         try:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -211,12 +211,14 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             galleries = await self.local_meural.send_get_galleries()
             gallery_status = await self.local_meural.send_get_gallery_status()
 
-            # Get gsensor orientation for orientationMatch detection.
-            # Failure here is non-critical; omit the key so callers can detect absence.
+            # Get gsensor orientation for orientationMatch detection and lux for illuminance sensor.
+            # Failure here is non-critical; omit the keys so callers can detect absence.
             gsensor = None
+            lux = None
             try:
                 system_info = await self.local_meural.send_get_system()
                 gsensor = system_info.get("gsensor")
+                lux = system_info.get("lux")
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 pass
 
@@ -225,6 +227,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "galleries": sorted(galleries, key=lambda i: i["name"]),
                 "gallery_status": gallery_status,
                 "gsensor": gsensor,
+                "lux": lux,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -217,12 +217,15 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             lux = None
             backlight = None
             free_space = None
+            wifi_signal = None
             try:
                 system_info = await self.local_meural.send_get_system()
                 gsensor = system_info.get("gsensor")
                 lux = system_info.get("lux")
                 backlight = system_info.get("backlight")
                 free_space = system_info.get("free_space")
+                wifi_status = system_info.get("wifi_status", {})
+                wifi_signal = wifi_status.get("signal")
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 pass
 
@@ -234,6 +237,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "lux": lux,
                 "backlight": backlight,
                 "free_space": free_space,
+                "wifi_signal": wifi_signal,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -216,11 +216,13 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             gsensor = None
             lux = None
             backlight = None
+            free_space = None
             try:
                 system_info = await self.local_meural.send_get_system()
                 gsensor = system_info.get("gsensor")
                 lux = system_info.get("lux")
                 backlight = system_info.get("backlight")
+                free_space = system_info.get("free_space")
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 pass
 
@@ -231,6 +233,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "gsensor": gsensor,
                 "lux": lux,
                 "backlight": backlight,
+                "free_space": free_space,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -174,6 +174,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.device_id = str(device["id"])
         self.local_meural = LocalMeural(device, session)
         self._sleeping = True
+        self.cloud_coordinator: CloudDataUpdateCoordinator | None = None
 
         super().__init__(
             hass,
@@ -196,15 +197,22 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch data from Meural local device API."""
         try:
             # Get sleep status
+            prev_sleeping = self._sleeping
             self._sleeping = await self.local_meural.send_get_sleep()
+            if prev_sleeping != self._sleeping and self.cloud_coordinator is not None:
+                self.cloud_coordinator.notify_sleep_state_changed()
 
             if self._sleeping:
-                # Device is sleeping, return minimal data
+                # Device is sleeping; preserve last known sensor values to avoid unknown state
                 cached = self.data or {}
                 return {
                     "sleeping": True,
                     "galleries": cached.get("galleries", []),
                     "gallery_status": cached.get("gallery_status", {}),
+                    "gsensor": cached.get("gsensor"),
+                    "backlight": cached.get("backlight"),
+                    "free_space": cached.get("free_space"),
+                    "wifi_signal": cached.get("wifi_signal"),
                 }
 
             # Device is awake, get full data

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -213,6 +213,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "backlight": cached.get("backlight"),
                     "free_space": cached.get("free_space"),
                     "wifi_signal": cached.get("wifi_signal"),
+                    "version": cached.get("version"),
                 }
 
             # Device is awake, get full data
@@ -226,6 +227,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             backlight = None
             free_space = None
             wifi_signal = None
+            version = None
             try:
                 system_info = await self.local_meural.send_get_system()
                 gsensor = system_info.get("gsensor")
@@ -234,6 +236,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 free_space = system_info.get("free_space")
                 wifi_status = system_info.get("wifi_status", {})
                 wifi_signal = wifi_status.get("signal")
+                version = system_info.get("version")
             except (aiohttp.ClientError, asyncio.TimeoutError):
                 pass
 
@@ -246,6 +249,7 @@ class LocalDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "backlight": backlight,
                 "free_space": free_space,
                 "wifi_signal": wifi_signal,
+                "version": version,
             }
 
         except (DeviceTurnedOff, aiohttp.ClientError, asyncio.TimeoutError) as err:

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -1,8 +1,11 @@
 """Light platform for Meural integration — controls Canvas backlight brightness."""
 from __future__ import annotations
 
+import logging
 import math
 from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -32,6 +35,7 @@ async def async_setup_entry(
 
     entities = []
     for device in devices:
+        _LOGGER.info("Adding Meural backlight light for device %s", device["alias"])
         local_coordinator = local_coordinators[str(device["id"])]
         entities.append(MeuralBacklightLight(local_coordinator, device))
 
@@ -87,10 +91,12 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         else:
             # Default to full brightness if no value given
             meural_brightness = 100
+        _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
         await self.coordinator.local_meural.send_control_backlight(meural_brightness)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off backlight (set brightness to 0)."""
+        _LOGGER.info("Meural device %s: Turning off backlight", self._device["alias"])
         await self.coordinator.local_meural.send_control_backlight(0)
         await self.coordinator.async_refresh()

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -58,6 +58,12 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         self._device = device
         self._attr_name = f"{device['alias']} Backlight"
         self._attr_unique_id = f"{device['id']}_backlight"
+        self._optimistic_brightness: int | None = None
+
+    def _handle_coordinator_update(self) -> None:
+        """Clear optimistic brightness once coordinator confirms the new value."""
+        self._optimistic_brightness = None
+        super()._handle_coordinator_update()
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -84,6 +90,8 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
     @property
     def brightness(self) -> int | None:
         """Return brightness scaled to HA range (0-255)."""
+        if self._optimistic_brightness is not None:
+            return self._optimistic_brightness
         level = self._meural_brightness()
         if level is None:
             return None
@@ -100,6 +108,8 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
             meural_brightness = round(ha_brightness * 100 / 255)
             _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
             await self.coordinator.local_meural.send_control_backlight(meural_brightness)
+            self._optimistic_brightness = ha_brightness
+            self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off backlight by suspending the Canvas device."""

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -101,8 +101,7 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         """Turn on / set brightness. Wakes device first if sleeping."""
         if self.coordinator.sleeping:
             await self.coordinator.local_meural.send_key_resume()
-            self.coordinator._sleeping = False
-            self.async_write_ha_state()
+            self.coordinator.set_sleeping_optimistic(False)
         ha_brightness = kwargs.get(ATTR_BRIGHTNESS)
         if ha_brightness is not None:
             meural_brightness = round(ha_brightness * 100 / 255)
@@ -115,6 +114,5 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         """Turn off backlight by suspending the Canvas device."""
         _LOGGER.info("Meural device %s: Turning off backlight (suspending device)", self._device["alias"])
         await self.coordinator.local_meural.send_key_suspend()
-        self.coordinator._sleeping = True
-        self.async_write_ha_state()
+        self.coordinator.set_sleeping_optimistic(True)
 

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -59,6 +59,13 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         self._attr_name = f"{device['alias']} Backlight"
         self._attr_unique_id = f"{device['id']}_backlight"
 
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information to link this entity to the Meural device."""
+        return {
+            "identifiers": {(DOMAIN, self._device["productKey"])},
+        }
+
     def _meural_brightness(self) -> int | None:
         """Return current backlight as a Meural value (0-100), or None if unavailable."""
         if not self.coordinator.data:

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -78,9 +78,8 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
 
     @property
     def is_on(self) -> bool:
-        """Return true if backlight is on (brightness > 0)."""
-        level = self._meural_brightness()
-        return level is not None and level > 0
+        """Backlight cannot be turned off independently; always on when data is available."""
+        return self.coordinator.data is not None
 
     @property
     def brightness(self) -> int | None:
@@ -102,8 +101,3 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         await self.coordinator.local_meural.send_control_backlight(meural_brightness)
         await self.coordinator.async_refresh()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off backlight (set brightness to 0)."""
-        _LOGGER.info("Meural device %s: Turning off backlight", self._device["alias"])
-        await self.coordinator.local_meural.send_control_backlight(0)
-        await self.coordinator.async_refresh()

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -78,8 +78,8 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
 
     @property
     def is_on(self) -> bool:
-        """Backlight cannot be turned off independently; always on when data is available."""
-        return self.coordinator.data is not None
+        """Return true if the device is awake (backlight is on)."""
+        return self.coordinator.data is not None and not self.coordinator.sleeping
 
     @property
     def brightness(self) -> int | None:
@@ -99,5 +99,12 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
             meural_brightness = 100
         _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
         await self.coordinator.local_meural.send_control_backlight(meural_brightness)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off backlight by suspending the Canvas device."""
+        _LOGGER.info("Meural device %s: Turning off backlight (suspending device)", self._device["alias"])
+        await self.coordinator.local_meural.send_key_suspend()
+        self.coordinator._sleeping = True
         await self.coordinator.async_refresh()
 

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -47,6 +47,7 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
 
     _attr_color_mode = ColorMode.BRIGHTNESS
     _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+    _attr_icon = "mdi:image"
 
     def __init__(
         self,

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -1,0 +1,96 @@
+"""Light platform for Meural integration — controls Canvas backlight brightness."""
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Meural light entities."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    cloud_coordinator: CloudDataUpdateCoordinator = entry_data["cloud_coordinator"]
+    local_coordinators: dict[str, LocalDataUpdateCoordinator] = entry_data["local_coordinators"]
+
+    devices = list(cloud_coordinator.data["devices"].values())
+
+    entities = []
+    for device in devices:
+        local_coordinator = local_coordinators[str(device["id"])]
+        entities.append(MeuralBacklightLight(local_coordinator, device))
+
+    async_add_entities(entities)
+
+
+class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightEntity):
+    """Backlight brightness control for a Meural Canvas device."""
+
+    _attr_color_mode = ColorMode.BRIGHTNESS
+    _attr_supported_color_modes = {ColorMode.BRIGHTNESS}
+
+    def __init__(
+        self,
+        coordinator: LocalDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_name = f"{device['alias']} Backlight"
+        self._attr_unique_id = f"{device['id']}_backlight"
+
+    def _meural_brightness(self) -> int | None:
+        """Return current backlight as a Meural value (0-100), or None if unavailable."""
+        if not self.coordinator.data:
+            return None
+        raw = self.coordinator.data.get("backlight")
+        try:
+            return int(raw) if raw is not None else None
+        except (ValueError, TypeError):
+            return None
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if backlight is on (brightness > 0)."""
+        level = self._meural_brightness()
+        return level is not None and level > 0
+
+    @property
+    def brightness(self) -> int | None:
+        """Return brightness scaled to HA range (0-255)."""
+        level = self._meural_brightness()
+        if level is None:
+            return None
+        return math.floor(level * 255 / 100)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on / set brightness."""
+        ha_brightness = kwargs.get(ATTR_BRIGHTNESS)
+        if ha_brightness is not None:
+            meural_brightness = round(ha_brightness * 100 / 255)
+        else:
+            # Default to full brightness if no value given
+            meural_brightness = 100
+        await self.coordinator.local_meural.send_control_backlight(meural_brightness)
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off backlight (set brightness to 0)."""
+        await self.coordinator.local_meural.send_control_backlight(0)
+        await self.coordinator.async_refresh()

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -90,15 +90,15 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         return math.floor(level * 255 / 100)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on / set brightness."""
+        """Turn on / set brightness. Wakes device first if sleeping."""
+        if self.coordinator.sleeping:
+            await self.coordinator.local_meural.send_key_resume()
+            self.coordinator._sleeping = False
         ha_brightness = kwargs.get(ATTR_BRIGHTNESS)
         if ha_brightness is not None:
             meural_brightness = round(ha_brightness * 100 / 255)
-        else:
-            # Default to full brightness if no value given
-            meural_brightness = 100
-        _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
-        await self.coordinator.local_meural.send_control_backlight(meural_brightness)
+            _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
+            await self.coordinator.local_meural.send_control_backlight(meural_brightness)
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -101,6 +101,7 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on / set brightness. Wakes device first if sleeping."""
         if self.coordinator.sleeping:
+            _LOGGER.info("Meural device %s: Turning on backlight (waking device)", self._device["alias"])
             await self.coordinator.local_meural.send_key_resume()
             self.coordinator.set_sleeping_optimistic(False)
         ha_brightness = kwargs.get(ATTR_BRIGHTNESS)

--- a/custom_components/meural/light.py
+++ b/custom_components/meural/light.py
@@ -94,17 +94,17 @@ class MeuralBacklightLight(CoordinatorEntity[LocalDataUpdateCoordinator], LightE
         if self.coordinator.sleeping:
             await self.coordinator.local_meural.send_key_resume()
             self.coordinator._sleeping = False
+            self.async_write_ha_state()
         ha_brightness = kwargs.get(ATTR_BRIGHTNESS)
         if ha_brightness is not None:
             meural_brightness = round(ha_brightness * 100 / 255)
             _LOGGER.info("Meural device %s: Setting backlight to %s%%", self._device["alias"], meural_brightness)
             await self.coordinator.local_meural.send_control_backlight(meural_brightness)
-        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off backlight by suspending the Canvas device."""
         _LOGGER.info("Meural device %s: Turning off backlight (suspending device)", self._device["alias"])
         await self.coordinator.local_meural.send_key_suspend()
         self.coordinator._sleeping = True
-        await self.coordinator.async_refresh()
+        self.async_write_ha_state()
 

--- a/custom_components/meural/manifest.json
+++ b/custom_components/meural/manifest.json
@@ -10,7 +10,7 @@
   "homekit": {},
   "dependencies": [],
   "after_dependencies": ["http", "media_source"],
-  "version": "2.0.0",
+  "version": "2.2.0",
   "codeowners": ["@guysie"],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -695,15 +695,13 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         # Optimistically mark as awake for immediate UI feedback.
         # No immediate refresh — the device takes several seconds to wake up and would
         # still report sleeping, overriding this update. The 10s poll will confirm.
-        self.local_coordinator._sleeping = False
-        self.async_write_ha_state()
+        self.local_coordinator.set_sleeping_optimistic(False)
 
     async def async_turn_off(self):
         """Suspend Meural frame display."""
         await self.local_meural.send_key_suspend()
         # Optimistically mark as sleeping for immediate UI feedback; refresh confirms.
-        self.local_coordinator._sleeping = True
-        self.async_write_ha_state()
+        self.local_coordinator.set_sleeping_optimistic(True)
         await self._refresh_after_user_action()
 
     async def async_media_pause(self):

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -200,6 +200,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         self._current_item: dict[str, Any] = {}
         self._pause_duration = 0
         self._last_fetched_item_id: int | None = None
+        self._last_gsensor: str | None = None
 
         # Start listening to local coordinator updates
         self.async_on_remove(
@@ -307,11 +308,33 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         self.cloud_coordinator.notify_sleep_state_changed()
 
         if self.local_coordinator.data:
-            # When local data updates, fetch current item if it changed
-            gallery_status = self.local_coordinator.data.get("gallery_status", {})
-            if gallery_status:
-                # Schedule fetching current item in the background
-                self.hass.async_create_task(self._fetch_current_item_if_needed())
+            # Detect physical rotation via gsensor when orientationMatch is enabled.
+            # gallery_status.current_item does not update on orientationMatch switches,
+            # so we use gsensor changes as the trigger to clear stale item metadata.
+            gsensor = self.local_coordinator.data.get("gsensor")
+            if (
+                gsensor is not None
+                and self._last_gsensor is not None
+                and gsensor != self._last_gsensor
+                and self._meural_device.get("orientationMatch")
+            ):
+                _LOGGER.debug(
+                    "Meural device %s: gsensor changed from %s to %s with orientationMatch enabled, reloading gallery to force item update",
+                    self.name,
+                    self._last_gsensor,
+                    gsensor,
+                )
+                self._current_item = {}
+                self._last_fetched_item_id = None
+                self.hass.async_create_task(self._reload_gallery_on_orientation_change())
+            else:
+                # When local data updates, fetch current item if it changed
+                gallery_status = self.local_coordinator.data.get("gallery_status", {})
+                if gallery_status:
+                    # Schedule fetching current item in the background
+                    self.hass.async_create_task(self._fetch_current_item_if_needed())
+            if gsensor is not None:
+                self._last_gsensor = gsensor
 
         self.async_write_ha_state()
 
@@ -602,6 +625,40 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         # Force immediate refresh for user-initiated actions (bypasses throttling)
         # This will automatically trigger _fetch_current_item_if_needed() via the coordinator update listener
         await self.local_coordinator.async_refresh()
+
+    async def _reload_gallery_on_orientation_change(self) -> None:
+        """Reload the current gallery after an orientationMatch rotation to force item update.
+
+        When the device physically rotates with orientationMatch enabled, it switches to an
+        orientation-appropriate item internally but gallery_status.current_item never updates
+        via the local API until the gallery naturally advances. Reloading the same gallery
+        forces the device to report the correct current_item.
+        """
+        if not self.local_coordinator.data:
+            return
+        gallery_status = self.local_coordinator.data.get("gallery_status", {})
+        current_gallery_id = gallery_status.get("current_gallery")
+        if not current_gallery_id or int(current_gallery_id) <= SD_CARD_FOLDER_MAX_ID:
+            return
+        _LOGGER.debug(
+            "Meural device %s: Reloading gallery %s to force current_item update after orientation change",
+            self.name,
+            current_gallery_id,
+        )
+        try:
+            # Wait for the orientation transition to complete before reloading.
+            # The transition animation takes several seconds; tune this if the reload
+            # still interrupts the transition or takes too long to respond.
+            await asyncio.sleep(5.0)
+            await self.local_meural.send_change_gallery(current_gallery_id)
+            await asyncio.sleep(1.0)
+            await self.local_coordinator.async_refresh()
+        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
+            _LOGGER.warning(
+                "Meural device %s: Error reloading gallery after orientation change: %s",
+                self.name,
+                err,
+            )
 
     async def async_select_source(self, source: str) -> None:
         """Select playlist to display."""

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -348,7 +348,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
             "name": self.name,
             "manufacturer": "NETGEAR",
             "model": self._meural_device["frameModel"]["name"],
-            "sw_version": self._meural_device["version"],
+            "sw_version": (self.local_coordinator.data or {}).get("version") or self._meural_device["version"],
             "configuration_url": f"http://{self._meural_device['localIp']}/remote/",
         }
 

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -19,7 +19,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.network import get_url
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.media_player import MediaClass, MediaType
 
@@ -60,25 +59,15 @@ async def async_setup_entry(
     entry_data = hass.data[DOMAIN][config_entry.entry_id]
     meural = entry_data["meural"]
     cloud_coordinator: CloudDataUpdateCoordinator = entry_data["cloud_coordinator"]
+    local_coordinators: dict[str, LocalDataUpdateCoordinator] = entry_data["local_coordinators"]
 
     # Get devices from cloud coordinator data
     devices = list(cloud_coordinator.data["devices"].values())
 
-    # Create entities with local coordinators
     entities = []
     for device in devices:
         _LOGGER.info("Adding Meural device %s", device['alias'])
-
-        # Create local coordinator for this device
-        local_coordinator = LocalDataUpdateCoordinator(
-            hass,
-            device,
-            async_get_clientsession(hass),
-        )
-
-        # Perform first refresh for local coordinator
-        await local_coordinator.async_config_entry_first_refresh()
-
+        local_coordinator = local_coordinators[str(device["id"])]
         entities.append(
             MeuralEntity(
                 meural,

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -1,7 +1,10 @@
 """Sensor platform for Meural integration."""
 from __future__ import annotations
 
+import logging
 from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -32,6 +35,7 @@ async def async_setup_entry(
 
     entities = []
     for device in devices:
+        _LOGGER.info("Adding Meural sensors for device %s", device["alias"])
         local_coordinator = local_coordinators[str(device["id"])]
         entities.append(MeuralLuxSensor(local_coordinator, device))
         entities.append(MeuralFreeSpaceSensor(local_coordinator, device))

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -1,0 +1,68 @@
+"""Sensor platform for Meural integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import LIGHT_LUX
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Meural sensor entities."""
+    entry_data = hass.data[DOMAIN][config_entry.entry_id]
+    cloud_coordinator: CloudDataUpdateCoordinator = entry_data["cloud_coordinator"]
+    local_coordinators: dict[str, LocalDataUpdateCoordinator] = entry_data["local_coordinators"]
+
+    devices = list(cloud_coordinator.data["devices"].values())
+
+    entities = []
+    for device in devices:
+        local_coordinator = local_coordinators[str(device["id"])]
+        entities.append(MeuralLuxSensor(local_coordinator, device))
+
+    async_add_entities(entities)
+
+
+class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+    """Ambient light sensor for a Meural Canvas device."""
+
+    _attr_device_class = SensorDeviceClass.ILLUMINANCE
+    _attr_native_unit_of_measurement = LIGHT_LUX
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: LocalDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_name = f"{device['alias']} Ambient Light"
+        self._attr_unique_id = f"{device['id']}_lux"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current lux value."""
+        if not self.coordinator.data:
+            return None
+        raw = self.coordinator.data.get("lux")
+        try:
+            return float(raw) if raw is not None else None
+        except (ValueError, TypeError):
+            return None

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -66,3 +66,5 @@ class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntit
             return float(raw) if raw is not None else None
         except (ValueError, TypeError):
             return None
+
+

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -94,6 +94,7 @@ class MeuralLuxSensor(MeuralSensorBase):
     _attr_device_class = SensorDeviceClass.ILLUMINANCE
     _attr_native_unit_of_measurement = LIGHT_LUX
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
 
     def __init__(
         self,
@@ -125,6 +126,7 @@ class MeuralFreeSpaceSensor(MeuralSensorBase):
     _attr_entity_registry_enabled_default = False
     _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
 
     def __init__(
         self,
@@ -152,6 +154,7 @@ class MeuralWifiSignalSensor(MeuralSensorBase):
     _attr_entity_registry_enabled_default = False
     _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 0
 
     def __init__(
         self,
@@ -189,7 +192,7 @@ class MeuralLastSeenSensor(MeuralCloudSensorBase):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device)
-        self._attr_name = f"{device['alias']} Last Cloud Contact"
+        self._attr_name = f"{device['alias']} Last Seen by Cloud"
         self._attr_unique_id = f"{device['id']}_last_seen"
 
     @property

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -122,6 +122,7 @@ class MeuralFreeSpaceSensor(MeuralSensorBase):
 
     _attr_device_class = SensorDeviceClass.DATA_SIZE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -148,6 +149,7 @@ class MeuralWifiSignalSensor(MeuralSensorBase):
 
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
     _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -178,7 +180,7 @@ class MeuralLastSeenSensor(MeuralCloudSensorBase):
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = True
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ from homeassistant.const import LIGHT_LUX, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, U
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import parse_datetime
 
 from .const import DOMAIN
 from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
@@ -40,8 +42,29 @@ async def async_setup_entry(
         entities.append(MeuralLuxSensor(local_coordinator, device))
         entities.append(MeuralFreeSpaceSensor(local_coordinator, device))
         entities.append(MeuralWifiSignalSensor(local_coordinator, device))
+        entities.append(MeuralLastSeenSensor(cloud_coordinator, device))
 
     async_add_entities(entities)
+
+
+class MeuralCloudSensorBase(CoordinatorEntity[CloudDataUpdateCoordinator], SensorEntity):
+    """Base class for Meural cloud-sourced sensor entities."""
+
+    def __init__(
+        self,
+        coordinator: CloudDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device = device
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information to link this entity to the Meural device."""
+        return {
+            "identifiers": {(DOMAIN, self._device["productKey"])},
+        }
 
 
 class MeuralSensorBase(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
@@ -145,4 +168,34 @@ class MeuralWifiSignalSensor(MeuralSensorBase):
             return float(raw) if raw is not None else None
         except (ValueError, TypeError):
             return None
+
+
+class MeuralLastSeenSensor(MeuralCloudSensorBase):
+    """Last seen timestamp sensor for a Meural Canvas device."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_registry_enabled_default = True
+
+    def __init__(
+        self,
+        coordinator: CloudDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, device)
+        self._attr_name = f"{device['alias']} Last Seen"
+        self._attr_unique_id = f"{device['id']}_last_seen"
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the last seen timestamp from cloud frameStatus."""
+        if not self.coordinator.data:
+            return None
+        device = self.coordinator.data.get("devices", {}).get(str(self._device["id"]))
+        if not device:
+            return None
+        raw = device.get("frameStatus", {}).get("lastSeen")
+        if not raw:
+            return None
+        return parse_datetime(raw)
 

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -44,7 +44,27 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+class MeuralSensorBase(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+    """Base class for Meural sensor entities."""
+
+    def __init__(
+        self,
+        coordinator: LocalDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device = device
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information to link this entity to the Meural device."""
+        return {
+            "identifiers": {(DOMAIN, self._device["productKey"])},
+        }
+
+
+class MeuralLuxSensor(MeuralSensorBase):
     """Ambient light sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.ILLUMINANCE
@@ -57,8 +77,7 @@ class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntit
         device: dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._attr_name = f"{device['alias']} Ambient Light"
         self._attr_unique_id = f"{device['id']}_lux"
 
@@ -74,7 +93,7 @@ class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntit
             return None
 
 
-class MeuralFreeSpaceSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+class MeuralFreeSpaceSensor(MeuralSensorBase):
     """Free storage space sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.DATA_SIZE
@@ -87,8 +106,7 @@ class MeuralFreeSpaceSensor(CoordinatorEntity[LocalDataUpdateCoordinator], Senso
         device: dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._attr_name = f"{device['alias']} Free Space"
         self._attr_unique_id = f"{device['id']}_free_space"
 
@@ -100,7 +118,7 @@ class MeuralFreeSpaceSensor(CoordinatorEntity[LocalDataUpdateCoordinator], Senso
         return self.coordinator.data.get("free_space")
 
 
-class MeuralWifiSignalSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+class MeuralWifiSignalSensor(MeuralSensorBase):
     """WiFi signal strength sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
@@ -113,8 +131,7 @@ class MeuralWifiSignalSensor(CoordinatorEntity[LocalDataUpdateCoordinator], Sens
         device: dict[str, Any],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator)
-        self._device = device
+        super().__init__(coordinator, device)
         self._attr_name = f"{device['alias']} WiFi Signal"
         self._attr_unique_id = f"{device['id']}_wifi_signal"
 

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LIGHT_LUX
+from homeassistant.const import LIGHT_LUX, UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -34,6 +34,7 @@ async def async_setup_entry(
     for device in devices:
         local_coordinator = local_coordinators[str(device["id"])]
         entities.append(MeuralLuxSensor(local_coordinator, device))
+        entities.append(MeuralFreeSpaceSensor(local_coordinator, device))
 
     async_add_entities(entities)
 
@@ -66,5 +67,31 @@ class MeuralLuxSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntit
             return float(raw) if raw is not None else None
         except (ValueError, TypeError):
             return None
+
+
+class MeuralFreeSpaceSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+    """Free storage space sensor for a Meural Canvas device."""
+
+    _attr_device_class = SensorDeviceClass.DATA_SIZE
+    _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: LocalDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_name = f"{device['alias']} Free Space"
+        self._attr_unique_id = f"{device['id']}_free_space"
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the current free space in MB."""
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get("free_space")
 
 

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import LIGHT_LUX, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfInformation
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -120,6 +121,7 @@ class MeuralFreeSpaceSensor(MeuralSensorBase):
     """Free storage space sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.DATA_SIZE
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = UnitOfInformation.MEGABYTES
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -145,6 +147,7 @@ class MeuralWifiSignalSensor(MeuralSensorBase):
     """WiFi signal strength sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
     _attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -174,6 +177,7 @@ class MeuralLastSeenSensor(MeuralCloudSensorBase):
     """Last seen timestamp sensor for a Meural Canvas device."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = True
 
     def __init__(
@@ -183,7 +187,7 @@ class MeuralLastSeenSensor(MeuralCloudSensorBase):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device)
-        self._attr_name = f"{device['alias']} Last Seen"
+        self._attr_name = f"{device['alias']} Last Cloud Contact"
         self._attr_unique_id = f"{device['id']}_last_seen"
 
     @property

--- a/custom_components/meural/sensor.py
+++ b/custom_components/meural/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LIGHT_LUX, UnitOfInformation
+from homeassistant.const import LIGHT_LUX, SIGNAL_STRENGTH_DECIBELS_MILLIWATT, UnitOfInformation
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -35,6 +35,7 @@ async def async_setup_entry(
         local_coordinator = local_coordinators[str(device["id"])]
         entities.append(MeuralLuxSensor(local_coordinator, device))
         entities.append(MeuralFreeSpaceSensor(local_coordinator, device))
+        entities.append(MeuralWifiSignalSensor(local_coordinator, device))
 
     async_add_entities(entities)
 
@@ -94,4 +95,33 @@ class MeuralFreeSpaceSensor(CoordinatorEntity[LocalDataUpdateCoordinator], Senso
             return None
         return self.coordinator.data.get("free_space")
 
+
+class MeuralWifiSignalSensor(CoordinatorEntity[LocalDataUpdateCoordinator], SensorEntity):
+    """WiFi signal strength sensor for a Meural Canvas device."""
+
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: LocalDataUpdateCoordinator,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        self._device = device
+        self._attr_name = f"{device['alias']} WiFi Signal"
+        self._attr_unique_id = f"{device['id']}_wifi_signal"
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current WiFi signal strength in dBm."""
+        if not self.coordinator.data:
+            return None
+        raw = self.coordinator.data.get("wifi_signal")
+        try:
+            return float(raw) if raw is not None else None
+        except (ValueError, TypeError):
+            return None
 

--- a/custom_components/meural/translations/en.json
+++ b/custom_components/meural/translations/en.json
@@ -1,12 +1,12 @@
 {
     "config": {
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+            "already_configured": "Device is already configured"
         },
         "error": {
-            "cannot_connect": "[%key:common::config_flow::abort::cannot_connect%]",
-            "invalid_auth": "[%key:common::config_flow::abort::invalid_auth%]",
-            "unknown": "[%key:common::config_flow::abort::unknown%]"
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication credentials",
+            "unknown": "Unexpected error"
         },
         "step": {
             "user": {


### PR DESCRIPTION
- **orientationMatch detection restored**: Automatic detection of physical device rotation via gsensor is back. The integration reloads the current gallery when the device rotates with orientationMatch enabled, keeping `current_item` metadata accurate.
- **Ambient light sensor**: New sensor reporting the Canvas ambient light level in lux, sourced from the local device API. The local coordinator now polls `send_get_system()` even when the Canvas is sleeping, so the ambient light (lux) sensor — and other local sensors — continue to update every 10 seconds while the device is off. 
- **Free Space sensor**: New diagnostic sensor reporting available Canvas storage space in megabytes. Disabled by default; enable in Home Assistant's entity settings.
- **WiFi Signal sensor**: New diagnostic sensor reporting Canvas WiFi signal strength in dBm. Disabled by default; enable in Home Assistant's entity settings.
- **Last Seen by Cloud sensor**: New diagnostic sensor reporting the last timestamp the device contacted the Meural cloud, useful for connectivity monitoring. Disabled by default; enable in Home Assistant's entity settings.
- **Backlight light entity**: New light entity for the Canvas backlight, allowing brightness control and on/off. Turning the light off suspends the Canvas; turning it on wakes it.
- **Local firmware version**: The Canvas firmware version shown in Home Assistant is now sourced from the local device API for accuracy.