### PR TITLE
Handle inaccessible playlist thumbnail items

### DIFF
--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -891,8 +891,17 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
                     album_items = await self.local_meural.send_get_items_by_gallery(g["id"])
                     if album_items:
                         _LOGGER.info("Meural device %s: Browsing media. Replacing missing thumbnail of gallery %s with first gallery item image. Getting information from Meural server for item %s", self.name, g["id"], album_items[0]["id"])
-                        first_item = await self.meural.get_item(album_items[0]["id"])
-                        thumb = first_item["image"]
+                        try:
+                            first_item = await self.meural.get_item(album_items[0]["id"])
+                            thumb = first_item["image"]
+                        except (aiohttp.ClientError, asyncio.TimeoutError, KeyError) as err:
+                            _LOGGER.warning(
+                                "Meural device %s: Browsing media. Could not fetch thumbnail for gallery %s item %s from Meural cloud: %s",
+                                self.name,
+                                g["id"],
+                                album_items[0]["id"],
+                                err,
+                            )
                 _LOGGER.debug("Meural device %s: Browsing media. Thumbnail image for gallery %s is %s", self.name, g["id"], thumb)
 
                 response.children.append(BrowseMedia(


### PR DESCRIPTION
Thank you for maintaining this integration. It keeps my Meural Canvases useful after 10+ years.

When browsing playlists for one of my Meurals, the media browser failed because one local playlist was missing a cloud cover and the fallback thumbnail lookup hit a Meural cloud `403 Forbidden` for the first item. That optional thumbnail error bubbled up and failed the entire browse request.

This change catches non-critical thumbnail lookup errors, logs a warning with the gallery/item id, and continues rendering the playlist list without that thumbnail.

I tested this locally on Home Assistant 2026.4.2 with ha-meural 2.2.0. It solved the playlist browsing error for my affected device.
