### PR TITLE
Improved playlist support

### DIFF
--- a/custom_components/meural/const.py
+++ b/custom_components/meural/const.py
@@ -10,3 +10,6 @@ LOCAL_UPDATE_INTERVAL = 10
 
 # SD card folder max ID
 SD_CARD_FOLDER_MAX_ID = 4
+
+# Recents playlist ID
+RECENTS_PLAYLIST_ID = 5

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -32,7 +32,7 @@ from homeassistant.components.media_player.const import (
     MediaPlayerEntityFeature
 )
 
-from .const import DOMAIN, SD_CARD_FOLDER_MAX_ID
+from .const import DOMAIN, SD_CARD_FOLDER_MAX_ID, RECENTS_PLAYLIST_ID
 from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,8 +156,17 @@ async def async_setup_entry(
 
     platform.async_register_entity_service(
         "play_random_playlist",
-        {},
+        {
+            vol.Optional("include_recents", default=True): bool,
+        },
         "async_play_random_playlist",
+    )
+
+    platform.async_register_entity_service(
+        "play_random_cloud_playlist",
+        {},
+        "async_play_random_cloud_playlist",
+        supports_response=True,
     )
 
     platform.async_register_entity_service(
@@ -167,6 +176,15 @@ async def async_setup_entry(
             vol.Optional("gallery_name"): str,
         },
         "async_load_playlist",
+    )
+
+    platform.async_register_entity_service(
+        "delete_playlist",
+        {
+            vol.Optional("gallery_id"): vol.Coerce(int),
+            vol.Optional("gallery_name"): str,
+        },
+        "async_delete_playlist",
     )
 
 class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEntity):
@@ -466,6 +484,19 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         """Boolean if shuffling is enabled."""
         return self._meural_device["imageShuffle"]
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return custom attributes."""
+        attributes = {}
+
+        if self.local_coordinator.data:
+            gallery_status = self.local_coordinator.data.get("gallery_status", {})
+            current_gallery_id = gallery_status.get("current_gallery")
+            if current_gallery_id is not None:
+                attributes["current_gallery_id"] = int(current_gallery_id)
+
+        return attributes
+
     async def async_set_device_option(
         self,
         orientation=None,
@@ -539,7 +570,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         await self.meural.sync_device(self.meural_device_id)
         await self.cloud_coordinator.async_refresh_galleries()
 
-    async def async_play_random_playlist(self):
+    async def async_play_random_playlist(self, include_recents=True):
         """Pick a random gallery from all available galleries and play it."""
         if not self.local_coordinator.data:
             _LOGGER.warning("Meural device %s: Play random playlist. No local data available", self.name)
@@ -554,6 +585,8 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         current_gallery_id = str(gallery_status.get("current_gallery", ""))
 
         candidate_galleries = [g for g in galleries if str(g["id"]) != current_gallery_id]
+        if not include_recents:
+            candidate_galleries = [g for g in candidate_galleries if g["id"] != RECENTS_PLAYLIST_ID]
         if not candidate_galleries:
             # Only one gallery available; play it regardless
             candidate_galleries = galleries
@@ -567,6 +600,48 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         )
         await self.local_meural.send_change_gallery(gallery["id"])
         await self._refresh_after_user_action()
+
+    async def async_play_random_cloud_playlist(self):
+        """Pick a random gallery from cloud and load it onto the device."""
+        # Get all cloud galleries (device galleries + user galleries)
+        device_galleries = self.cloud_coordinator.data.get("device_galleries", {}).get(self.meural_device_id, [])
+        user_galleries = self.cloud_coordinator.data.get("user_galleries", [])
+        
+        # Deduplicate by ID
+        seen_ids: set[int] = set()
+        all_cloud_galleries: list[dict] = []
+        for g in device_galleries + user_galleries:
+            if g["id"] not in seen_ids:
+                seen_ids.add(g["id"])
+                all_cloud_galleries.append(g)
+
+        if not all_cloud_galleries:
+            _LOGGER.warning("Meural device %s: Load random cloud playlist. No cloud galleries available", self.name)
+            return
+
+        # Get current gallery ID to avoid selecting the same one
+        if self.local_coordinator.data:
+            gallery_status = self.local_coordinator.data.get("gallery_status", {})
+            current_gallery_id = gallery_status.get("current_gallery")
+        else:
+            current_gallery_id = None
+
+        candidate_galleries = [g for g in all_cloud_galleries if g["id"] != current_gallery_id]
+        if not candidate_galleries:
+            # Only one gallery available; load it regardless
+            candidate_galleries = all_cloud_galleries
+
+        gallery = random.choice(candidate_galleries)
+        _LOGGER.info(
+            "Meural device %s: Load random cloud playlist. Loading random cloud gallery %s, ID %s",
+            self.name,
+            gallery["name"],
+            gallery["id"],
+        )
+        await self.meural.device_load_gallery(self.meural_device_id, gallery["id"])
+        await self.local_meural.send_change_gallery(gallery["id"])
+        await self._refresh_after_user_action()
+        return {"gallery_id": gallery["id"]}
 
     async def async_load_playlist(self, gallery_id=None, gallery_name=None):
         """Load the latest cloud version of a gallery onto the device."""
@@ -604,6 +679,44 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
             resolved_id,
         )
         await self.meural.device_load_gallery(self.meural_device_id, resolved_id)
+        await self._refresh_after_user_action()
+
+    async def async_delete_playlist(self, gallery_id=None, gallery_name=None):
+        """Remove a gallery from the device."""
+        if gallery_id is None and gallery_name is None:
+            _LOGGER.error("Meural device %s: Delete playlist. Must provide gallery_id or gallery_name", self.name)
+            return
+
+        resolved_id = gallery_id
+
+        if resolved_id is None:
+            # Look up by name in cloud coordinator data
+            device_galleries = self.cloud_coordinator.data.get("device_galleries", {}).get(self.meural_device_id, [])
+            user_galleries = self.cloud_coordinator.data.get("user_galleries", [])
+            seen_ids: set[int] = set()
+            all_galleries: list[dict] = []
+            for g in device_galleries + user_galleries:
+                if g["id"] not in seen_ids:
+                    seen_ids.add(g["id"])
+                    all_galleries.append(g)
+            match = next((g for g in all_galleries if g["name"] == gallery_name), None)
+            if match is None:
+                available_names = [g["name"] for g in all_galleries]
+                _LOGGER.error(
+                    "Meural device %s: Delete playlist. Gallery '%s' not found in cloud data. Available galleries: %s",
+                    self.name,
+                    gallery_name,
+                    available_names,
+                )
+                return
+            resolved_id = match["id"]
+
+        _LOGGER.info(
+            "Meural device %s: Delete playlist. Removing gallery ID %s from device",
+            self.name,
+            resolved_id,
+        )
+        await self.meural.delete_device_gallery(self.meural_device_id, resolved_id)
         await self._refresh_after_user_action()
 
     async def _refresh_after_user_action(self) -> None:

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -15,7 +15,7 @@ from homeassistant.components import media_source
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.media_player import BrowseError, BrowseMedia
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.network import get_url
@@ -166,7 +166,7 @@ async def async_setup_entry(
         "play_random_cloud_playlist",
         {},
         "async_play_random_cloud_playlist",
-        supports_response=True,
+        supports_response=SupportsResponse.ONLY,
     )
 
     platform.async_register_entity_service(
@@ -641,7 +641,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         await self.meural.device_load_gallery(self.meural_device_id, gallery["id"])
         await self.local_meural.send_change_gallery(gallery["id"])
         await self._refresh_after_user_action()
-        return gallery["id"]
+        return {"id": gallery["id"], "name": gallery["name"]}
 
     async def async_load_playlist(self, gallery_id=None, gallery_name=None):
         """Load the latest cloud version of a gallery onto the device."""

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -166,7 +166,7 @@ async def async_setup_entry(
         "play_random_cloud_playlist",
         {},
         "async_play_random_cloud_playlist",
-        supports_response=SupportsResponse.ONLY,
+        supports_response=SupportsResponse.OPTIONAL,
     )
 
     platform.async_register_entity_service(

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -641,7 +641,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
         await self.meural.device_load_gallery(self.meural_device_id, gallery["id"])
         await self.local_meural.send_change_gallery(gallery["id"])
         await self._refresh_after_user_action()
-        return {"gallery_id": gallery["id"]}
+        return gallery["id"]
 
     async def async_load_playlist(self, gallery_id=None, gallery_name=None):
         """Load the latest cloud version of a gallery onto the device."""

--- a/custom_components/meural/pymeural.py
+++ b/custom_components/meural/pymeural.py
@@ -96,7 +96,7 @@ class PyMeural:
         self.token_update_callback = token_update_callback
         self._auth_lock = asyncio.Lock()
 
-    async def request(self, method: str, path: str, data: dict[str, Any] | None = None) -> dict[str, Any]:
+    async def request(self, method: str, path: str, data: dict[str, Any] | None = None, timeout: int = 10) -> dict[str, Any]:
         fetched_new_token = self.token is None
         if self.token is None:
             await self.get_new_token()
@@ -107,7 +107,7 @@ class PyMeural:
                 kwargs["params"] = data
             else:
                 kwargs["json"] = data
-        with async_timeout.timeout(10):
+        with async_timeout.timeout(timeout):
             try:
                 resp = await self.session.request(
                     method,
@@ -182,7 +182,7 @@ class PyMeural:
 
     async def device_load_gallery(self, device_id: str | int, gallery_id: str | int) -> dict[str, Any]:
         """Load a gallery on a device."""
-        return await self.request("post", f"devices/{device_id}/galleries/{gallery_id}")
+        return await self.request("post", f"devices/{device_id}/galleries/{gallery_id}", timeout=30)
 
     async def delete_device_gallery(self, device_id: str | int, gallery_id: str | int) -> dict[str, Any]:
         """Remove a gallery from a device."""

--- a/custom_components/meural/pymeural.py
+++ b/custom_components/meural/pymeural.py
@@ -184,6 +184,10 @@ class PyMeural:
         """Load a gallery on a device."""
         return await self.request("post", f"devices/{device_id}/galleries/{gallery_id}")
 
+    async def delete_device_gallery(self, device_id: str | int, gallery_id: str | int) -> dict[str, Any]:
+        """Remove a gallery from a device."""
+        return await self.request("delete", f"devices/{device_id}/galleries/{gallery_id}")
+
     async def device_load_item(self, device_id: str | int, item_id: str | int) -> dict[str, Any]:
         """Load an item on a device."""
         return await self.request("post", f"devices/{device_id}/items/{item_id}")

--- a/custom_components/meural/services.yaml
+++ b/custom_components/meural/services.yaml
@@ -6,6 +6,21 @@ play_random_playlist:
     entity_id:
       description: Entity ID of the Meural Canvas to update.
       example: "media_player.meural-123"
+    include_recents:
+      description: Whether to include the Recents playlist in the random selection. Defaults to true.
+      example: "false"
+play_random_cloud_playlist:
+  description: Pick a random playlist from the Meural cloud and load it onto the Canvas. Returns the gallery_id of the selected playlist.
+  fields:
+    entity_id:
+      description: Entity ID of the Meural Canvas to update.
+      example: "media_player.meural-123"
+  response:
+    optional: false
+    fields:
+      gallery_id:
+        description: Numeric ID of the selected gallery/playlist.
+        example: "12345"
 set_brightness:
   description: Change backlight brightness setting of the Meural Canvas.
   fields:
@@ -111,3 +126,21 @@ load_playlist:
     gallery_name:
       description: Name of the gallery/playlist to load. Provide either this or gallery_id. If both are provided, gallery_id takes precedence.
       example: "My Art Collection"
+delete_playlist:
+  description: Remove a playlist from the Meural Canvas.
+  fields:
+    entity_id:
+      description: Entity ID of the Meural Canvas to update.
+      example: "media_player.meural-123"
+    gallery_id:
+      description: Numeric ID of the gallery/playlist to remove. Provide either this or gallery_name.
+      example: "12345"
+    gallery_name:
+      description: Name of the gallery/playlist to remove. Provide either this or gallery_id. If both are provided, gallery_id takes precedence.
+      example: "My Art Collection"
+delete_current_playlist:
+  description: Remove the currently playing playlist from the Meural Canvas.
+  fields:
+    entity_id:
+      description: Entity ID of the Meural Canvas to update.
+      example: "media_player.meural-123"


### PR DESCRIPTION
* Added `delete_playlist` service to remove a playlist from a Canvas
* Added optional parameter to `play_random_playlist` to include or include the built in `Recents` playlist
* Added `play_random_cloud_playlist` service to allow loading a random playlist from the cloud onto the Canvas. Similar to `play_random_playlist` but for playlists not currently on the device
* Added a `current_gallery_id` attribute to get the id of the currently playing playlist