### PR TITLE
Handle upstream auth failures (WAF blocks) gracefully and add reauth flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,9 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 - Uses AWS Cognito (boto3) for authentication with automatic token refresh
 - Handles authentication token lifecycle with callback for persistent storage
 - All API methods are async and use aiohttp
+- Classifies Cognito auth failures by error code: `NotAuthorizedException`/`UserNotFoundException` raise `InvalidAuth` (genuinely bad credentials); anything else (WAF blocks, throttling, network errors) raises `CannotConnect` so it doesn't misreport as bad credentials
+- On auth failure, applies exponential backoff (60s, doubling up to a 30 min cap) before allowing another full authentication attempt, to avoid hammering a blocked/rate-limited auth endpoint
+- Backoff state is keyed by account email in module-level state (`_AUTH_BACKOFF_STATE`), not on the `PyMeural` instance, since Home Assistant recreates the client on every `ConfigEntryNotReady` setup retry; resets on successful auth or full HA restart
 
 **LocalMeural** (`pymeural.py`):
 - Local device API client for Canvas web server (http://DEVICE-IP/remote/)
@@ -95,7 +98,9 @@ The integration uses two DataUpdateCoordinators for efficient polling:
 2. PyMeural authenticates with AWS Cognito, receives access + refresh tokens
 3. Tokens stored in config entry via `token_update_callback`
 4. Access token automatically refreshed when expired
-5. If refresh token fails, triggers Home Assistant reauth flow
+5. If refresh token fails, falls through to full authentication with the stored password
+6. If full authentication fails with genuinely invalid credentials (`InvalidAuth`), the cloud coordinator raises `ConfigEntryAuthFailed`, which triggers Home Assistant's reauth flow (`async_step_reauth`/`async_step_reauth_confirm` in `config_flow.py`), prompting the user for a new password
+7. If authentication instead fails due to a connectivity problem (`CannotConnect` — e.g. an upstream WAF block or throttling), the coordinator raises `UpdateFailed` for retry instead, so reauth is not triggered on what may just be a transient upstream block
 
 ### Data Flow
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Log in with your NETGEAR account.
 
 **Note 2:** If you are upgrading to v2.0.0 from v1.x, the upgrade is fully backward compatible — no re-configuration or re-authentication is needed. Home Assistant will handle the migration automatically on restart. However, if you are upgrading from v0.x, you have to delete this integration in *Settings*, *Devices & Services*, *Integrations*, and then re-add it to log in again. This will set up the configuration entries required by v1.0.0 and later.  
 
+**Note 3:** If your login stops working, Home Assistant will prompt you to reauthenticate with a notification under *Settings* → *Devices & Services*. Since v2.4.0, this only happens for genuinely invalid credentials. Temporary upstream issues connecting to the Meural cloud (e.g. rate limiting) are treated as connectivity failures instead — the integration backs off and retries automatically rather than asking you to log in again.  
+
 ### Media Player
 The integration will detect all Canvas devices registered to your account. Each Canvas will become a Media Player entity and can be added to your dashboard using any component that supports it, for example the standard Media Control card. By default your entity's name will correspond to the name of the Canvas, which out-of-the-box consists of a painter's name and 3 digits like `picasso-428` - resulting in the entity `media_player.picasso-428` being created. You can override the name and entity ID in Home Assistant's entity settings.  
 

--- a/custom_components/meural/config_flow.py
+++ b/custom_components/meural/config_flow.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -17,6 +19,7 @@ from . import pymeural
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema({"email": str, "password": str})
+REAUTH_DATA_SCHEMA = vol.Schema({"password": str})
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> tuple[str, str]:
@@ -32,6 +35,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Meural."""
 
     VERSION = 1
+
+    _reauth_entry: ConfigEntry | None = None
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step."""
@@ -64,4 +69,56 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Handle reauthentication triggered by an authentication failure."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the reauth confirmation form."""
+        errors: dict[str, str] = {}
+        assert self._reauth_entry is not None
+        email = self._reauth_entry.data["email"]
+
+        if user_input is not None:
+            _LOGGER.debug("Attempting reauthentication for %s", email)
+            try:
+                token, refresh_token = await validate_input(
+                    self.hass, {"email": email, "password": user_input["password"]}
+                )
+                _LOGGER.info("Successfully reauthenticated Meural account %s", email)
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry,
+                    data={
+                        **self._reauth_entry.data,
+                        "password": user_input["password"],
+                        "token": token,
+                        "refresh_token": refresh_token,
+                    },
+                )
+                await self.hass.config_entries.async_reload(
+                    self._reauth_entry.entry_id
+                )
+                return self.async_abort(reason="reauth_successful")
+            except pymeural.CannotConnect:
+                _LOGGER.warning("Cannot connect to Meural API for %s", email)
+                errors["base"] = "cannot_connect"
+            except pymeural.InvalidAuth:
+                _LOGGER.warning("Invalid credentials for Meural account %s", email)
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=REAUTH_DATA_SCHEMA,
+            description_placeholders={"email": email},
+            errors=errors,
         )

--- a/custom_components/meural/coordinator.py
+++ b/custom_components/meural/coordinator.py
@@ -20,7 +20,7 @@ from .const import (
     GALLERY_UPDATE_INTERVAL,
     LOCAL_UPDATE_INTERVAL,
 )
-from .pymeural import DeviceTurnedOff, InvalidAuth, LocalMeural, PyMeural
+from .pymeural import CannotConnect, DeviceTurnedOff, InvalidAuth, LocalMeural, PyMeural
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ class CloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "Meural Cloud: Gallery data refreshed (%d user galleries)",
                 len(user_galleries),
             )
-        except (InvalidAuth, aiohttp.ClientError, asyncio.TimeoutError) as err:
+        except (InvalidAuth, CannotConnect, aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.warning("Meural Cloud: Failed to refresh gallery data: %s", err)
         finally:
             self._gallery_refresh_in_progress = False
@@ -148,11 +148,13 @@ class CloudDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         except InvalidAuth as err:
             # Authentication failed - trigger reauth flow
+            _LOGGER.warning("Meural Cloud: Authentication failed, triggering reauth: %s", err)
             raise ConfigEntryAuthFailed(
                 "Authentication failed. Please reauthenticate."
             ) from err
-        except (aiohttp.ClientError, asyncio.TimeoutError) as err:
-            # Network error - raise UpdateFailed for retry
+        except (CannotConnect, aiohttp.ClientError, asyncio.TimeoutError) as err:
+            # Network error (including upstream WAF/rate-limit blocks) - raise
+            # UpdateFailed for retry, without triggering the reauth flow.
             raise UpdateFailed(f"Error communicating with Meural cloud API: {err}") from err
         except Exception as err:
             # Unexpected error

--- a/custom_components/meural/manifest.json
+++ b/custom_components/meural/manifest.json
@@ -10,7 +10,7 @@
   "homekit": {},
   "dependencies": [],
   "after_dependencies": ["http", "media_source"],
-  "version": "2.3.0",
+  "version": "2.4.0",
   "codeowners": ["@guysie"],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/meural/media_player.py
+++ b/custom_components/meural/media_player.py
@@ -34,6 +34,7 @@ from homeassistant.components.media_player.const import (
 
 from .const import DOMAIN, SD_CARD_FOLDER_MAX_ID
 from .coordinator import CloudDataUpdateCoordinator, LocalDataUpdateCoordinator
+from .pymeural import CannotConnect, InvalidAuth
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -261,7 +262,7 @@ class MeuralEntity(CoordinatorEntity[CloudDataUpdateCoordinator], MediaPlayerEnt
                     self._last_fetched_item_id = current_item_id
                     # Update UI with new thumbnail
                     self.async_write_ha_state()
-            except (aiohttp.ClientError, asyncio.TimeoutError, KeyError) as err:
+            except (aiohttp.ClientError, asyncio.TimeoutError, KeyError, InvalidAuth, CannotConnect) as err:
                 _LOGGER.warning(
                     "Meural device %s: Error getting current item information: %s",
                     self.name,

--- a/custom_components/meural/pymeural.py
+++ b/custom_components/meural/pymeural.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 import json
-from typing import Any, Callable
+import time
+from typing import Any, Callable, NoReturn
 
 import aiohttp
 import async_timeout
 import boto3
+from botocore.exceptions import ClientError as BotoClientError
 
 from aiohttp.client_exceptions import ClientResponseError
 
@@ -20,6 +22,45 @@ BASE_URL = "https://api.meural.com/v0/"
 AUTH_CLIENT_NAME = "cognito-idp"
 AUTH_CLIENT_REGION = "eu-west-1"
 AUTH_CLIENT_CLIENTID = "487bd4kvb1fnop6mbgk8gu5ibf"
+
+# Cognito error codes that mean the credentials themselves were rejected.
+# Anything else (WAF blocks, throttling, network errors) is a connectivity
+# problem, not proof the username/password is wrong.
+COGNITO_INVALID_CREDENTIAL_CODES = {"NotAuthorizedException", "UserNotFoundException"}
+
+
+def _raise_for_auth_error(err: Exception) -> NoReturn:
+    """Classify an auth-request exception as InvalidAuth or CannotConnect."""
+    if isinstance(err, BotoClientError):
+        code = err.response.get("Error", {}).get("Code", "")
+        if code in COGNITO_INVALID_CREDENTIAL_CODES:
+            raise InvalidAuth from err
+    raise CannotConnect from err
+
+# Backoff before retrying full authentication after a failure, to avoid hammering
+# the auth endpoint (e.g. during an upstream WAF/rate-limit block). Doubles on each
+# consecutive failure up to the cap, and resets after a success.
+AUTH_RETRY_BACKOFF_BASE = 60
+AUTH_RETRY_BACKOFF_MAX = 1800
+
+
+def _auth_backoff_seconds(failure_count: int) -> float:
+    """Return the backoff duration for the given number of consecutive auth failures."""
+    return min(AUTH_RETRY_BACKOFF_BASE * (2 ** (failure_count - 1)), AUTH_RETRY_BACKOFF_MAX)
+
+
+# Auth backoff state keyed by account email, kept at module scope (rather than on
+# PyMeural instances) so it survives Home Assistant recreating the PyMeural instance
+# on every ConfigEntryNotReady setup retry - otherwise a sustained upstream block
+# (e.g. WAF) would keep resetting the backoff and get hit on every retry. Resets
+# naturally on a full Home Assistant restart.
+_AUTH_BACKOFF_STATE: dict[str, dict[str, Any]] = {}
+
+
+def _get_auth_backoff_state(username: str) -> dict[str, Any]:
+    return _AUTH_BACKOFF_STATE.setdefault(
+        username, {"last_failure": 0.0, "failure_count": 0, "error_type": CannotConnect}
+    )
 
 
 async def authenticate(
@@ -36,7 +77,11 @@ async def authenticate(
             AuthParameters={"USERNAME": username, "PASSWORD": password},
         )
 
-    response = await asyncio.to_thread(initiate_auth)
+    try:
+        response = await asyncio.to_thread(initiate_auth)
+    except Exception as err:
+        _LOGGER.warning("Meural: Authentication request failed: %s", err)
+        _raise_for_auth_error(err)
 
     if "AuthenticationResult" in response:
         auth_result = response["AuthenticationResult"]
@@ -45,6 +90,10 @@ async def authenticate(
         _LOGGER.debug("Meural: Authentication successful, tokens received")
         return access_token, refresh_token
 
+    _LOGGER.warning(
+        "Meural: Authentication response missing expected result (challenge: %s)",
+        response.get("ChallengeName", "unknown"),
+    )
     raise InvalidAuth
 
 
@@ -64,15 +113,19 @@ async def refresh_access_token(
 
     try:
         response = await asyncio.to_thread(initiate_auth_refresh)
-
-        if "AuthenticationResult" in response:
-            access_token = response["AuthenticationResult"]["AccessToken"]
-            _LOGGER.debug("Meural: Access token refreshed successfully")
-            return access_token
     except Exception as err:
         _LOGGER.warning("Meural: Failed to refresh token: %s", err)
-        raise InvalidAuth from err
+        _raise_for_auth_error(err)
 
+    if "AuthenticationResult" in response:
+        access_token = response["AuthenticationResult"]["AccessToken"]
+        _LOGGER.debug("Meural: Access token refreshed successfully")
+        return access_token
+
+    _LOGGER.warning(
+        "Meural: Refresh response missing expected result (challenge: %s)",
+        response.get("ChallengeName", "unknown"),
+    )
     raise InvalidAuth
 
 class PyMeural:
@@ -121,9 +174,17 @@ class PyMeural:
                 )
             except ClientResponseError as err:
                 if err.status != 401:
+                    _LOGGER.error(
+                        "Meural: Sending request to %s failed with status %s: %s",
+                        path, err.status, err.message,
+                    )
                     raise
                 # If a new token was just fetched and it fails again, just raise
                 if fetched_new_token:
+                    _LOGGER.error(
+                        "Meural: Sending request to %s failed. Freshly fetched token was rejected (401): %s",
+                        path, err.message,
+                    )
                     raise
                 _LOGGER.info('Meural: Sending Request failed. Re-Authenticating')
                 self.token = None
@@ -141,24 +202,67 @@ class PyMeural:
             if self.token is not None:
                 return
 
-            # Try to refresh using refresh token first
-            if self.refresh_token:
-                try:
-                    _LOGGER.debug("Meural: Attempting to refresh access token")
-                    self.token = await refresh_access_token(self.session, self.refresh_token)
-                    # Update only access token, keep existing refresh token
-                    self.token_update_callback(self.token, self.refresh_token)
-                    return
-                except InvalidAuth:
-                    _LOGGER.info("Meural: Refresh token invalid, performing full authentication")
-                    # Refresh token is invalid, fall through to full authentication
+            # Back off after a recent failure instead of hammering the auth endpoint
+            # on every subsequent request (e.g. while an upstream WAF/rate-limit block
+            # is in effect). Backoff doubles with each consecutive failure. Keyed by
+            # account in module-level state, since Home Assistant recreates this
+            # PyMeural instance on every ConfigEntryNotReady setup retry.
+            backoff_state = _get_auth_backoff_state(self.username)
+            if backoff_state["last_failure"]:
+                backoff = _auth_backoff_seconds(backoff_state["failure_count"])
+                time_since_failure = time.monotonic() - backoff_state["last_failure"]
+                if time_since_failure < backoff:
+                    remaining = backoff - time_since_failure
+                    _LOGGER.debug(
+                        "Meural: Backing off authentication for %.0fs after %d consecutive failure(s)",
+                        remaining,
+                        backoff_state["failure_count"],
+                    )
+                    # Re-raise the same error type as the failure that caused this
+                    # backoff, so a WAF/network block still reports as CannotConnect
+                    # rather than being misreported as bad credentials.
+                    raise backoff_state["error_type"](
+                        f"Skipping authentication attempt, retrying in {remaining:.0f}s"
+                    )
 
-            # Full authentication with username and password
-            _LOGGER.info("Meural: Performing full authentication")
-            self.token, self.refresh_token = await authenticate(
-                self.session, self.username, self.password
-            )
-            self.token_update_callback(self.token, self.refresh_token)
+            try:
+                # Try to refresh using refresh token first
+                if self.refresh_token:
+                    try:
+                        _LOGGER.debug("Meural: Attempting to refresh access token")
+                        self.token = await refresh_access_token(self.session, self.refresh_token)
+                        # Update only access token, keep existing refresh token
+                        self.token_update_callback(self.token, self.refresh_token)
+                        return
+                    except InvalidAuth:
+                        _LOGGER.info("Meural: Refresh token invalid, performing full authentication")
+                        # Refresh token is invalid, fall through to full authentication
+
+                # Full authentication with username and password
+                _LOGGER.info("Meural: Performing full authentication")
+                self.token, self.refresh_token = await authenticate(
+                    self.session, self.username, self.password
+                )
+                self.token_update_callback(self.token, self.refresh_token)
+            except (InvalidAuth, CannotConnect) as err:
+                backoff_state["last_failure"] = time.monotonic()
+                backoff_state["failure_count"] += 1
+                backoff_state["error_type"] = type(err)
+                _LOGGER.warning(
+                    "Meural: Authentication failed (%s: %s), backing off for %.0fs before retrying",
+                    type(err).__name__,
+                    err.__cause__ or err,
+                    _auth_backoff_seconds(backoff_state["failure_count"]),
+                )
+                raise
+            else:
+                if backoff_state["failure_count"]:
+                    _LOGGER.info(
+                        "Meural: Authentication recovered after %d failed attempt(s)",
+                        backoff_state["failure_count"],
+                    )
+                backoff_state["last_failure"] = 0.0
+                backoff_state["failure_count"] = 0
 
     async def get_user(self) -> dict[str, Any]:
         """Get user information."""

--- a/custom_components/meural/strings.json
+++ b/custom_components/meural/strings.json
@@ -6,6 +6,13 @@
           "email": "Email",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate Meural",
+        "description": "The Meural integration needs to re-authenticate for {email}.",
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -14,7 +21,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/custom_components/meural/translations/en.json
+++ b/custom_components/meural/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "cannot_connect": "Failed to connect",
@@ -13,6 +14,13 @@
                 "data": {
                     "password": "Password",
                     "email": "Email"
+                }
+            },
+            "reauth_confirm": {
+                "title": "Reauthenticate Meural",
+                "description": "The Meural integration needs to re-authenticate for {email}.",
+                "data": {
+                    "password": "Password"
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Distinguish genuinely invalid credentials (`InvalidAuth`) from connectivity failures like WAF blocks or throttling (`CannotConnect`), based on the Cognito error code, so reauth prompts and config flow errors aren't misleading during an upstream block
- Add exponential backoff (60s–30min, keyed by account at module scope so it survives Home Assistant recreating the client on setup retries) to stop repeatedly hammering a blocked auth endpoint
- Implement the previously-missing `async_step_reauth`/`async_step_reauth_confirm` so `ConfigEntryAuthFailed` actually surfaces a reauth prompt as advertised
- Close several gaps where auth failures were silently swallowed instead of logged
- Bump version to 2.4.0
- Update CLAUDE.md and README.md to document the new auth behavior

## Test plan
- [ ] Verify normal login still works via config flow
- [ ] Verify invalid credentials trigger `InvalidAuth` and a reauth prompt (not a false "cannot connect")
- [ ] Simulate an upstream block/throttle response and confirm it raises `CannotConnect`/`UpdateFailed` without triggering reauth, and that backoff prevents repeated auth attempts
- [ ] Confirm reauth flow form appears, accepts a new password, and reloads the config entry on success
- [ ] Run hassfest validation via GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)